### PR TITLE
build.gradle: update `site-githuburl` and `site-seedu`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,9 +201,8 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level4',
-        'site-githuburl': 'https://github.com/se-edu/addressbook-level4',
-        'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
+        'site-name': 'PlanWithEase',
+        'site-githuburl': 'https://github.com/cs2113-ay1819s2-t09-1/main',
     ]
 
     options['template_dirs'].each {


### PR DESCRIPTION
The gradle configuration file does not include our project URL, and treats our project as a SE-EDU project.

Let's update `build.gradle` to fix this, which in turn fixes #21.