### PR TITLE
README.adoc: update Travis CI badge URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = PlanWithEase
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/cs2113-ay1819s2-t09-1/main[image:https://img.shields.io/travis/cs2113-ay1819s2-t09-1/main/master.svg?logo=travis-ci&logoColor=FFDC00&cacheSeconds=0[Travis CI Build Status]]
+https://travis-ci.org/CS2113-AY1819S2-T09-1/main[image:https://img.shields.io/travis/CS2113-AY1819S2-T09-1/main/master.svg?logo=travis-ci&logoColor=FFDC00&cacheSeconds=0[Travis CI Build Status]]
 https://ci.appveyor.com/project/Creastery/main[image:https://img.shields.io/appveyor/ci/Creastery/main/master.svg?logo=appveyor&logoColor=39CCCC&cacheSeconds=0[AppVeyor CI Build Status]]
 https://coveralls.io/github/cs2113-ay1819s2-t09-1/main?branch=master[image:https://img.shields.io/coveralls/github/cs2113-ay1819s2-t09-1/main.svg?logo=reverbnation&logoColor=FF851B&cacheSeconds=0[Coveralls Code Coverage Status]]
 https://www.codacy.com/app/cs2113-ay1819s2-t09-1/main[image:https://img.shields.io/codacy/grade/fb54572137f043de9b9913f791b4017f.svg?logo=codacy&logoColor=white&cacheSeconds=0[Codacy Code Quality Status]]


### PR DESCRIPTION
We renamed our GitHub organisation name from `cs2113-ay1819s2-t09-1` to
`CS2113-AY1819S2-T09-1`.

This resulted in a change of the project URL on Travis, which also
affected the Travis CI badge URL, causing the badge URL to point to an
unknown repository (`cs2113-ay1819s2-t09-1/main`).

Let's update the Travis CI badge URL so that it points to the correct
repository and show the correct build status again.