### PR TITLE
[#40] Add `_reposense/config.json` to make repository RepoSense-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ lib/*
 *.log
 *.log.*
 *.csv
-config.json
+/config.json
 src/test/data/sandbox/
 preferences.json
 .DS_Store

--- a/_reposense/config.json
+++ b/_reposense/config.json
@@ -1,0 +1,30 @@
+{
+  "authors":
+  [
+    {
+      "githubId": "truegitnovice",
+      "displayName": "AHN...GYU",
+      "authorNames": ["truegitnovice", "Ahn TaeGyu"]
+    },
+    {
+      "githubId": "WendyBaiYunwei",
+      "displayName": "BAI...WEI",
+      "authorNames": ["WendyBaiYunwei", "Bai Yunwei"]
+    },
+    {
+      "githubId": "lycjackie",
+      "displayName": "LEE...HOY",
+      "authorNames": ["lycjackie", "Jackie Lee"]
+    },
+    {
+      "githubId": "Creastery",
+      "displayName": "NGO...LIN",
+      "authorNames": ["Creastery", "Ngo Wei Lin"]
+    },
+    {
+      "githubId": "chyeo",
+      "displayName": "YEO...ONG",
+      "authorNames": ["chyeo", "CH YEO", "Yeo Cheng Hong"]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #40.

We are required to configure our repository to be RepoSense-compatible
by v1.3 milestone.

To make our repository RepoSense-compatible, let's:
* add RepoSense configuration file (`_reposense/config.json`),
* update `.gitignore` to only ignore `/config.json` so that the
  RepoSense `config.json` configuration file is not ignored.