### PR TITLE
Logic: update command prefixes and usages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,21 +18,23 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to module list. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
-            + PREFIX_CREDITS + "CREDITS "
             + PREFIX_CODE + "CODE "
+            + PREFIX_CREDITS + "CREDITS "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
-            + PREFIX_CREDITS + "98765432 "
-            + PREFIX_CODE + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_NAME + "Programming Methodology "
+            + PREFIX_CODE + "CS1010 "
+            + PREFIX_CREDITS + "004 "
+            + PREFIX_TAG + "programming "
+            + PREFIX_TAG + "algorithms "
+            + PREFIX_TAG + "c "
+            + PREFIX_TAG + "imperative";
 
     public static final String MESSAGE_SUCCESS = "New module added: %1$s";
-    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the module list";
 
     private final Module toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Module list has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -37,11 +37,11 @@ public class EditCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
-            + "[" + PREFIX_CREDITS + "CREDITS] "
             + "[" + PREFIX_CODE + "CODE] "
+            + "[" + PREFIX_CREDITS + "CREDITS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_CREDITS + "91234567 ";
+            + PREFIX_CREDITS + "008 ";
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -10,7 +10,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting PlanWithEase as requested ...";
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,13 +19,13 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all modules whose names, code or credits"
-            + "contain any of the specified keywords (case-insensitive)"
+            + " contain any of the specified keywords (case-insensitive)"
             + " and displays them as a list with index numbers.\n"
             + "Parameters: "
-            + "[" + PREFIX_NAME + "NAME name...]"
-            + "[" + PREFIX_CODE + "CODE code...]\n"
-            + "[" + PREFIX_CREDITS + "CREDITS credits ...]"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie\n";
+            + "[" + PREFIX_NAME + "NAME name...] "
+            + "[" + PREFIX_CODE + "CODE code...] "
+            + "[" + PREFIX_CREDITS + "CREDITS credits ...]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Programming Methodology\n";
 
     private final KeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,9 +6,9 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_CREDITS = new Prefix("p/");
-    public static final Prefix PREFIX_CODE = new Prefix("a/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_NAME = new Prefix("name/");
+    public static final Prefix PREFIX_CODE = new Prefix("code/");
+    public static final Prefix PREFIX_CREDITS = new Prefix("credits/");
+    public static final Prefix PREFIX_TAG = new Prefix("tag/");
 
 }


### PR DESCRIPTION
After the initial refactoring in PRs #18, #27, #30:
* command prefixes were left unchanged
* command messages, such as command usage, are not updated

This results in a mismatch in prefix value and the name of the 
`CliSyntax_PREFIX_`-constants, as well as a mismatch in command messages
and what our application does.

Let's update the prefix values in `CliSyntax`, and the `MESSAGE`-related
constants in `Logic/commands` accordingly.