### PR TITLE
docs/team: remove `dataencryption` tag to fix `asciidoctor` warning

### DIFF
--- a/docs/team/chyeo.adoc
+++ b/docs/team/chyeo.adoc
@@ -53,7 +53,6 @@ _{you can add/remove categories in the list above}_
 
 include::../UserGuide.adoc[tag=undoredo]
 
-include::../UserGuide.adoc[tag=dataencryption]
 
 == Contributions to the Developer Guide
 
@@ -63,7 +62,6 @@ include::../UserGuide.adoc[tag=dataencryption]
 
 include::../DeveloperGuide.adoc[tag=undoredo]
 
-include::../DeveloperGuide.adoc[tag=dataencryption]
 
 
 == PROJECT: PowerPointLabs

--- a/docs/team/creastery.adoc
+++ b/docs/team/creastery.adoc
@@ -53,7 +53,6 @@ _{you can add/remove categories in the list above}_
 
 include::../UserGuide.adoc[tag=undoredo]
 
-include::../UserGuide.adoc[tag=dataencryption]
 
 == Contributions to the Developer Guide
 
@@ -63,7 +62,6 @@ include::../UserGuide.adoc[tag=dataencryption]
 
 include::../DeveloperGuide.adoc[tag=undoredo]
 
-include::../DeveloperGuide.adoc[tag=dataencryption]
 
 
 == PROJECT: PowerPointLabs

--- a/docs/team/lycjackie.adoc
+++ b/docs/team/lycjackie.adoc
@@ -53,7 +53,6 @@ _{you can add/remove categories in the list above}_
 
 include::../UserGuide.adoc[tag=undoredo]
 
-include::../UserGuide.adoc[tag=dataencryption]
 
 == Contributions to the Developer Guide
 
@@ -63,7 +62,6 @@ include::../UserGuide.adoc[tag=dataencryption]
 
 include::../DeveloperGuide.adoc[tag=undoredo]
 
-include::../DeveloperGuide.adoc[tag=dataencryption]
 
 
 == PROJECT: PowerPointLabs

--- a/docs/team/truegitnovice.adoc
+++ b/docs/team/truegitnovice.adoc
@@ -53,7 +53,6 @@ _{you can add/remove categories in the list above}_
 
 include::../UserGuide.adoc[tag=undoredo]
 
-include::../UserGuide.adoc[tag=dataencryption]
 
 == Contributions to the Developer Guide
 
@@ -63,7 +62,6 @@ include::../UserGuide.adoc[tag=dataencryption]
 
 include::../DeveloperGuide.adoc[tag=undoredo]
 
-include::../DeveloperGuide.adoc[tag=dataencryption]
 
 
 == PROJECT: PowerPointLabs

--- a/docs/team/wendybaiyunwei.adoc
+++ b/docs/team/wendybaiyunwei.adoc
@@ -53,7 +53,6 @@ _{you can add/remove categories in the list above}_
 
 include::../UserGuide.adoc[tag=undoredo]
 
-include::../UserGuide.adoc[tag=dataencryption]
 
 == Contributions to the Developer Guide
 
@@ -63,7 +62,6 @@ include::../UserGuide.adoc[tag=dataencryption]
 
 include::../DeveloperGuide.adoc[tag=undoredo]
 
-include::../DeveloperGuide.adoc[tag=dataencryption]
 
 
 == PROJECT: PowerPointLabs


### PR DESCRIPTION
After PR #50 was merged, there was a dangling reference to
the `dataencryption` tag on all developer's Personal Project Portfolio.

Let's fix this issue by removing the dangling references to the
non-existent `dataencryption` tag on all portfolios.