### PR TITLE
DeveloperGuide: add `find` module use case

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -851,7 +851,8 @@ _{More to be added}_
 [appendix]
 == Use Cases
 
-(For all use cases below, the *System* is the `AddressBook` and the *Actor* is the `user`, unless specified otherwise)
+(For all use cases below, the *System* is the PlanWithEase `Application` and the *Actor* is the `user`, unless
+specified otherwise)
 
 [discrete]
 === Use case: Delete module
@@ -879,7 +880,32 @@ Use case ends.
 +
 Use case resumes at step 2.
 
-_{More to be added}_
+[discrete]
+=== Use case: Find a module
+*Guarantee(s):*
+
+* Modules will be listed if the input from the user is valid and can be matches the existing entries in the module list. +
+
+*MSS*
+
+. User requests to find modules with their keyword of choice.
+. Application shows a list of modules matched the keyword.
++
+Use case ends.
+
+*Extensions*
+[none]
+* 1a. The given input is invalid.
+** 1a1. Application shows an error message that given input is invalid.
++
+Use case ends.
+
+[none]
+* 2a. The module list is empty.
+** 2a1. Application shows an error message that module list is empty.
++
+Use case ends.
+
 
 [appendix]
 == Non Functional Requirements


### PR DESCRIPTION
The use case in the developer guide does not reflect most of our system
functional requirements.

A newer developer that wish to contribute would have a harder time to
ensure the proper behaviour between the system and the user.

Let’s add a use case to show a representation of a user’s interaction
with the system