### PR TITLE
UI: update `ModuleCard` and `ModuleListCard.fxml`

### DIFF
--- a/src/main/java/seedu/address/ui/ModuleCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCard.java
@@ -44,7 +44,7 @@ public class ModuleCard extends UiPart<Region> {
         this.module = module;
         id.setText(displayedIndex + ". ");
         name.setText(module.getName().fullName);
-        credits.setText(module.getCredits().value);
+        credits.setText(module.getCredits().value + " Module Credits");
         code.setText(module.getCode().value);
         module.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -25,11 +25,11 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="code" styleClass="cell_big_label" text="\$code" />
       </HBox>
-      <FlowPane fx:id="tags" />
+      <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       <Label fx:id="credits" styleClass="cell_small_label" text="\$credits" />
-      <Label fx:id="code" styleClass="cell_small_label" text="\$code" />
+      <FlowPane fx:id="tags" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/guitests/guihandles/ModuleCardHandle.java
+++ b/src/test/java/guitests/guihandles/ModuleCardHandle.java
@@ -53,7 +53,11 @@ public class ModuleCardHandle extends NodeHandle<Node> {
     }
 
     public String getCredits() {
-        return creditsLabel.getText();
+        String credits = creditsLabel.getText();
+        if (credits.endsWith(" Module Credits")) {
+            credits = credits.substring(0, credits.length() - " Module Credits".length());
+        }
+        return credits;
     }
 
     public List<String> getTags() {


### PR DESCRIPTION
The details in the `ModuleListCard` sidebar are difficult to comprehend.
Example: Credits are displayed as is without any labels, and users may
be confused or might not remember what the value means or represents.

Let's update the UI to make the data presented in the `ModuleListCard`
easier for users to comprehend by
* labelling the `Credits` value displayed
* re-ordering some of details presented to make it look neater
* update `ModuleCardHandle#getCredits()` to remove the label added