### PR TITLE
Model: update `Name#VALIDATION_REGEX`

### DIFF
--- a/src/main/java/seedu/address/model/module/Name.java
+++ b/src/main/java/seedu/address/model/module/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters, punctuations and spaces, but it should not be blank";
 
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Graph}][\\p{Print}]*";
 
     public final String fullName;
 

--- a/src/test/data/JsonAddressBookStorageTest/invalidModuleAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidModuleAddressBook.json
@@ -1,6 +1,6 @@
 {
   "modules": [ {
-    "name": "Module with invalid name field: Ha!ns Mu@ster",
+    "name": "Module with invalid name field: Ha!ns Muäster",
     "credits": "9482424",
     "code": "4th street"
   } ]

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,7 +43,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "Jame§"; // '§' not allowed in names
     public static final String INVALID_CREDITS_DESC = " " + PREFIX_CREDITS + "911a"; // 'a' not allowed in credits
     public static final String INVALID_CODE_DESC = " " + PREFIX_CODE; // empty string not allowed for codes
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -23,7 +23,7 @@ import seedu.address.model.tag.Tag;
 import seedu.address.testutil.Assert;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Rächel";
     private static final String INVALID_CREDITS = "+651234";
     private static final String INVALID_CODE = " ";
     private static final String INVALID_TAG = "#friend";

--- a/src/test/java/seedu/address/model/module/NameTest.java
+++ b/src/test/java/seedu/address/model/module/NameTest.java
@@ -28,8 +28,8 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
-        assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("µ")); // only non-printable character
+        assertFalse(Name.isValidName("pëter")); // contains non-printable characters
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
@@ -17,7 +17,7 @@ import seedu.address.model.module.Name;
 import seedu.address.testutil.Assert;
 
 public class JsonAdaptedModuleTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Rächel";
     private static final String INVALID_CREDITS = "+651234";
     private static final String INVALID_CODE = " ";
     private static final String INVALID_TAG = "#friend";


### PR DESCRIPTION
`Name#VALIDATION_REGEX` accepts any alphanumeric characters separated by
spaces. However, this character set is too strict, and prevents the use
of punctuation characters.

Example:
"Software Engineering & Object-Oriented Programming" is invalid.

Let's relax the `Name` restrictions by accepting punctuation characters
in `Name` by:
* replacing `\p{Alnum}` with `\p{Graph}` (alphanumeric + punctuations)
* replacing `\p{Alnum} ` with `\p{Print}` (`\p{Graph}` + whitespace)
* updating `Name#MESSAGE_CONSTRAINTS` to reflect the changes accordingly

In addition, let's also update unit tests that checks for invalid names.

_Note: The User Guide will be updated at a later time to reflect the changes in the constraints of the `Name` argument._