### PR TITLE
Logic: Fix `FindCommandParser#getKeywordsPredicate(...)`

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,13 +6,17 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.CodeContainsKeywordsPredicate;
+import seedu.address.model.module.Credits;
 import seedu.address.model.module.CreditsContainsKeywordsPredicate;
 import seedu.address.model.module.KeywordsPredicate;
+import seedu.address.model.module.Name;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
 
 /**
@@ -42,17 +46,20 @@ public class FindCommandParser implements Parser<FindCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
         KeywordsPredicate predicate = null;
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String[] nameKeywords = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get())
-                    .toString().split("\\s+");
-            predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            String[] nameArgs = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            List<String> nameKeywords = ParserUtil.parseMultiNames(nameArgs).stream().map(Name::toString)
+                    .collect(Collectors.toList());
+            predicate = new NameContainsKeywordsPredicate(nameKeywords);
         } else if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
-            String[] codeKeywords = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE)
-                    .get()).toString().split("\\s+");
-            predicate = new CodeContainsKeywordsPredicate(Arrays.asList(codeKeywords));
+            String[] codeArgs = argMultimap.getValue(PREFIX_CODE).get().split("\\s+");
+            List<String> codeKeywords = ParserUtil.parseMultiCodes(codeArgs).stream().map(Code::toString)
+                    .collect(Collectors.toList());
+            predicate = new CodeContainsKeywordsPredicate(codeKeywords);
         } else if (argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
-            String[] creditKeywords = ParserUtil.parseCredits(argMultimap.getValue(PREFIX_CREDITS)
-                    .get()).toString().split("\\s+");
-            predicate = new CreditsContainsKeywordsPredicate(Arrays.asList(creditKeywords));
+            String[] creditsArgs = argMultimap.getValue(PREFIX_CREDITS).get().split("\\s+");
+            List<String> creditKeywords = ParserUtil.parseMultiCredits(creditsArgs).stream()
+                    .map(Credits::toString).collect(Collectors.toList());
+            predicate = new CreditsContainsKeywordsPredicate(creditKeywords);
         } else {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -24,6 +26,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -50,6 +53,25 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String... name} into a {@code List<Name>}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code name} is invalid.
+     */
+    public static List<Name> parseMultiNames(String... names) throws ParseException {
+        List<Name> result = new ArrayList<>();
+        requireNonNull(names);
+        for (String name : names) {
+            String trimmedName = name.trim();
+            if (!Name.isValidName(trimmedName)) {
+                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            }
+            result.add(new Name(trimmedName));
+        }
+        return result;
+    }
+
+    /**
      * Parses a {@code String credits} into a {@code Credits}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -65,6 +87,25 @@ public class ParserUtil {
     }
 
     /**
+     * Parses a {@code String... credits} into a {@code List<Credits>}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code credits} is invalid.
+     */
+    public static List<Credits> parseMultiCredits(String... credits) throws ParseException {
+        List<Credits> result = new ArrayList<>();
+        requireNonNull(credits);
+        for (String credit : credits) {
+            String trimmedCredits = credit.trim();
+            if (!Credits.isValidCredits(trimmedCredits)) {
+                throw new ParseException(Credits.MESSAGE_CONSTRAINTS);
+            }
+            result.add(new Credits(trimmedCredits));
+        }
+        return result;
+    }
+
+    /**
      * Parses a {@code String code} into an {@code Code}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -77,6 +118,25 @@ public class ParserUtil {
             throw new ParseException(Code.MESSAGE_CONSTRAINTS);
         }
         return new Code(trimmedCode);
+    }
+
+    /**
+     * Parses a {@code String... code} into an {@code List<Code>}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code code} is invalid.
+     */
+    public static List<Code> parseMultiCodes(String... codes) throws ParseException {
+        List<Code> result = new ArrayList<>();
+        requireNonNull(codes);
+        for (String code : codes) {
+            String trimmedCode = code.trim();
+            if (!Code.isValidCode(trimmedCode)) {
+                throw new ParseException(Code.MESSAGE_CONSTRAINTS);
+            }
+            result.add(new Code(trimmedCode));
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -11,6 +12,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.module.CodeContainsKeywordsPredicate;
 import seedu.address.model.module.CreditsContainsKeywordsPredicate;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
 
@@ -21,29 +23,57 @@ public class FindCommandParserTest {
     @Test
     public void parse_emptyArg_throwsParseException() {
         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // No name argument -> assertFailure
+        assertParseFailure(parser, PREFIX_NAME + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // No code argument -> assertFailure
+        assertParseFailure(parser, PREFIX_CODE + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // No credits argument -> assertFailure
+        assertParseFailure(parser, PREFIX_CREDITS + "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindNameCommand =
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice")));
+        FindCommand expectedFindMultipleNameCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "find " + PREFIX_NAME + "Alice Bob", expectedFindNameCommand);
+        // single keyword
+        assertParseSuccess(parser, "find " + PREFIX_NAME + "Alice", expectedFindNameCommand);
+        // multiple keywords
+        assertParseSuccess(parser, "find " + PREFIX_NAME + "Alice Bob", expectedFindMultipleNameCommand);
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "find " + PREFIX_NAME + "  Alice       Bob     ", expectedFindNameCommand);
+        assertParseSuccess(parser, "find " + PREFIX_NAME + "  Alice       Bob     ", expectedFindMultipleNameCommand);
 
-        // TODO: @lycjackie - Fix bug in FindCommandParser that breaks unit test
-        /*
         FindCommand expectedFindCodeCommand =
+                new FindCommand(new CodeContainsKeywordsPredicate(Arrays.asList("CS1231")));
+        FindCommand expectedFindMultipleCodeCommand =
                 new FindCommand(new CodeContainsKeywordsPredicate(Arrays.asList("CS1231", "GET1004")));
-        assertParseSuccess(parser, "find " + PREFIX_CODE + "CS1231 GET1004", expectedFindCodeCommand);
-        */
+        // single keyword
+        assertParseSuccess(parser, "find " + PREFIX_CODE + "CS1231", expectedFindCodeCommand);
+        // multiple keywords
+        assertParseSuccess(parser, "find " + PREFIX_CODE + "CS1231 GET1004", expectedFindMultipleCodeCommand);
+        // multiple whitespaces keywords
+        assertParseSuccess(parser, "find " + PREFIX_CODE + "          CS1231           GET1004          ",
+                expectedFindMultipleCodeCommand);
 
         /* TODO: Due to the regex `Credits` have now, the test case does not reflect an actual Module Credits
          This will be update after proper regex is done. */
         FindCommand expectedFindCreditsCommand =
                 new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999")));
+        FindCommand expectedFindMultipleCreditsCommand =
+                new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999", "004", "012")));
+        // single keyword
         assertParseSuccess(parser, "find " + PREFIX_CREDITS + "999", expectedFindCreditsCommand);
+        // multiple keywords
+        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "999 004 012",
+                expectedFindMultipleCreditsCommand);
+        // multiple whitespaces keywords
+        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "        999           004        012",
+                expectedFindMultipleCreditsCommand);
     }
 
 }


### PR DESCRIPTION
As mention in #78, the logic flow in splitting the keywords was not done
properly.

The current behaviour is
1. Get the argument after find `PREFIX`
2. Form an `object` with the argument
3. Convert the `object` into `String`
4. Split the `String` by whitespaces

The expected behaviour should be:
1. Split each argument by whitespaces after the `PREFIX`
2. Form individual `object` for every `String`
3. Convert each individual `object `to `String`
4. Form the search `keywords` using each `String`

Let’s update `FindCommandParser#getKeywordsPredicate(…)` to
follow the expected behaviour and fix #78 

* [1/3] [Logic/ParserUtil: add more helper methods](https://github.com/CS2113-AY1819S2-T09-1/main/pull/79/commits/f500d7e05ca3e611aac3845055da48eb131efa3a)
* [2/3] [Logic: Fix `FindCommandParser#getKeywordsPredicate(...)`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/79/commits/e954bce2e3d11cae8f8e9e3a21606ae777923e02)
* [3/3] [test/parser: add unit tests to `FindCommandParserTest`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/79/commits/b8404b8e85a7a7da2311f5b15116378e68398dd4)
