### PR TITLE
Model: update `Credits#VALIDATION_REGEX`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -27,7 +27,7 @@ public class AddCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Programming Methodology "
             + PREFIX_CODE + "CS1010 "
-            + PREFIX_CREDITS + "004 "
+            + PREFIX_CREDITS + "4 "
             + PREFIX_TAG + "programming "
             + PREFIX_TAG + "algorithms "
             + PREFIX_TAG + "c "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -41,7 +41,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_CREDITS + "CREDITS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_CREDITS + "008 ";
+            + PREFIX_CREDITS + "8 ";
 
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/model/module/Credits.java
+++ b/src/main/java/seedu/address/model/module/Credits.java
@@ -10,8 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Credits {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Credits should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Credits should only contain numbers between 0 and 999.";
+    public static final String VALIDATION_REGEX = "0|([\\d&&[^0]]{1}[\\d]{0,2})";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -19,37 +19,68 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     private static final Module CS1010 = new Module(
             new Name("Programming Methodology"),
-            new Credits("004"),
+            new Credits("4"),
             new Code("CS1010"),
             getTagSet("programming", "algorithms", "c", "imperative")
     );
 
     private static final Module CS1231 = new Module(
             new Name("Discrete Structures"),
-            new Credits("004"),
+            new Credits("4"),
             new Code("CS1231"),
             getTagSet("math", "logic", "proving")
     );
 
     private static final Module CS2040C = new Module(
             new Name("Data Structures and Algorithms"),
-            new Credits("004"),
+            new Credits("4"),
             new Code("CS2040C"),
             getTagSet("linkedlist", "stack", "queue", "hashtable", "heap", "avltree", "graph", "sssp")
     );
 
     private static final Module CS2100 = new Module(
             new Name("Computer Organisation"),
-            new Credits("004"),
+            new Credits("4"),
             new Code("CS2100"),
             getTagSet("boolean", "mips", "assembly", "circuit", "flipflop", "pipelining", "cache")
     );
 
     private static final Module CS2102 = new Module(
             new Name("Database Systems"),
-            new Credits("004"),
+            new Credits("4"),
             new Code("CS2102"),
             getTagSet("database", "rdbms", "entity", "sql", "normalisation")
+    );
+
+    private static final RequirementCategory COMPUTING_FOUNDATION = new RequirementCategory(
+            new Name("Computing Foundation"), new Credits("36"), getCodeSet()
+    );
+    private static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategory(
+            new Name("Information Security Requirements"), new Credits("32"), getCodeSet()
+    );
+
+    private static final RequirementCategory INFORMATION_SECURITY_ELECTIVES = new RequirementCategory(
+            new Name("Information Security Electives"), new Credits("12"), getCodeSet()
+    );
+
+    private static final RequirementCategory COMPUTING_BREADTH = new RequirementCategory(
+            new Name("Computing Breadth"), new Credits("20"), getCodeSet()
+    );
+
+    private static final RequirementCategory IT_PROFESSIONALISM = new RequirementCategory(
+            new Name("IT Professionalism"), new Credits("8"), getCodeSet()
+    );
+
+    private static final RequirementCategory MATHEMATICS = new RequirementCategory(
+            new Name("Mathematics"), new Credits("12"), getCodeSet()
+    );
+
+    private static final RequirementCategory GENERAL_EDUCATION = new RequirementCategory(
+            new Name("General Education"), new Credits("20"), getCodeSet()
+    );
+
+    private static final RequirementCategory UNRESTRICTED_ELECTIVES = new RequirementCategory(
+            new Name("Unrestricted Electives"), new Credits("12"), getCodeSet()
     );
 
     public static Module[] getSampleModules() {
@@ -60,22 +91,14 @@ public class SampleDataUtil {
 
     public static RequirementCategory[] getSampleRequirementCategories() {
         return new RequirementCategory[] {
-            new RequirementCategory(new Name("Computing Foundation"), new Credits("036"),
-                getCodeSet()),
-            new RequirementCategory(new Name("Information Security Requirements"), new Credits("032"),
-                getCodeSet()),
-            new RequirementCategory(new Name("Information Security Electives"), new Credits("012"),
-                getCodeSet()),
-            new RequirementCategory(new Name("Computing Breadth"), new Credits("020"),
-                getCodeSet()),
-            new RequirementCategory(new Name("IT Professionalism"), new Credits("008"),
-                getCodeSet()),
-            new RequirementCategory(new Name("Mathematics"), new Credits("012"),
-                getCodeSet()),
-            new RequirementCategory(new Name("General Education"), new Credits("020"),
-                getCodeSet()),
-            new RequirementCategory(new Name("Unrestricted Electives"), new Credits("012"),
-                getCodeSet())
+            COMPUTING_FOUNDATION,
+            INFORMATION_SECURITY_REQUIREMENTS,
+            INFORMATION_SECURITY_ELECTIVES,
+            COMPUTING_BREADTH,
+            IT_PROFESSIONALISM,
+            MATHEMATICS,
+            GENERAL_EDUCATION,
+            UNRESTRICTED_ELECTIVES
         };
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateModuleAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateModuleAddressBook.json
@@ -1,12 +1,12 @@
 {
   "modules": [ {
     "name": "Alice Pauline",
-    "credits": "94351253",
+    "credits": "123",
     "code": "CS1010",
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
-    "credits": "94351253",
+    "credits": "123",
     "code": "CS1010"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
@@ -2,37 +2,37 @@
   "_comment": "AddressBook save file which contains the same Module values as in TypicalModules#getTypicalAddressBook()",
   "modules" : [ {
     "name" : "Alice Pauline",
-    "credits" : "94351253",
+    "credits" : "0",
     "code" : "CS1010",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
-    "credits" : "98765432",
+    "credits" : "1",
     "code" : "CS1231",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
-    "credits" : "95352563",
+    "credits" : "2",
     "code" : "CS2040C",
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
-    "credits" : "87652533",
+    "credits" : "3",
     "code" : "CS2100",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
-    "credits" : "9482224",
+    "credits" : "4",
     "code" : "CS2101",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
-    "credits" : "9482427",
+    "credits" : "5",
     "code" : "CS2102",
     "tagged" : [ ]
   }, {
     "name" : "George Best",
-    "credits" : "9482442",
+    "credits" : "6",
     "code" : "CS2105",
     "tagged" : [ ]
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
@@ -1,35 +1,35 @@
 {
   "requirementCategories" : [ {
     "name" : "Computing Foundation",
-    "credits" : "036",
+    "credits" : "36",
     "codeList" : [ ]
   }, {
     "name" : "Information Security Requirements",
-    "credits" : "032",
+    "credits" : "32",
     "codeList" : [ ]
   }, {
     "name" : "Information Security Electives",
-    "credits" : "012",
+    "credits" : "12",
     "codeList" : [ ]
   }, {
     "name" : "Computing Breadth",
-    "credits" : "020",
+    "credits" : "20",
     "codeList" : [ ]
   }, {
     "name" : "IT Professionalism",
-    "credits" : "008",
+    "credits" : "8",
     "codeList" : [ ]
   }, {
     "name" : "Mathematics",
-    "credits" : "012",
+    "credits" : "12",
     "codeList" : [ ]
   }, {
     "name" : "General Education",
-    "credits" : "020",
+    "credits" : "20",
     "codeList" : [ ]
   }, {
     "name" : "Unrestricted Electives",
-    "credits" : "012",
+    "credits" : "12",
     "codeList" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -27,8 +27,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_CREDITS_AMY = "11111111";
-    public static final String VALID_CREDITS_BOB = "22222222";
+    public static final String VALID_CREDITS_AMY = "0";
+    public static final String VALID_CREDITS_BOB = "999";
     public static final String VALID_CODE_AMY = "CS1010";
     public static final String VALID_CODE_BOB = "CS1231";
     public static final String VALID_TAG_HUSBAND = "husband";
@@ -44,7 +44,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "Jame§"; // '§' not allowed in names
-    public static final String INVALID_CREDITS_DESC = " " + PREFIX_CREDITS + "911a"; // 'a' not allowed in credits
+    public static final String INVALID_CREDITS_DESC = " " + PREFIX_CREDITS + "1a"; // 'a' not allowed in credits
     public static final String INVALID_CODE_DESC = " " + PREFIX_CODE; // empty string not allowed for codes
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -104,7 +104,7 @@ public class FindCommandTest {
     public void execute_multipleCreditsKeywords_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
         // TODO: update the module credits after TypicalModule attribute are updated
-        CreditsContainsKeywordsPredicate predicate = prepareCreditsPredicate("95352563 9482224 9482427");
+        CreditsContainsKeywordsPredicate predicate = prepareCreditsPredicate("2 4 5");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -65,14 +65,14 @@ public class FindCommandParserTest {
         FindCommand expectedFindCreditsCommand =
                 new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999")));
         FindCommand expectedFindMultipleCreditsCommand =
-                new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999", "004", "012")));
+                new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999", "4", "12")));
         // single keyword
         assertParseSuccess(parser, "find " + PREFIX_CREDITS + "999", expectedFindCreditsCommand);
         // multiple keywords
-        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "999 004 012",
+        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "999 4 12",
                 expectedFindMultipleCreditsCommand);
         // multiple whitespaces keywords
-        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "        999           004        012",
+        assertParseSuccess(parser, "find " + PREFIX_CREDITS + "        999           4        12",
                 expectedFindMultipleCreditsCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -29,7 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_CREDITS = "123456";
+    private static final String VALID_CREDITS = "246";
     private static final String VALID_CODE = "MA1301";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";

--- a/src/test/java/seedu/address/model/module/CodeContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/module/CodeContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class CodeContainsKeywordsPredicateTest {
 
         // Keywords match credits and name, but does not match code
         predicate = new CodeContainsKeywordsPredicate(Arrays.asList("CS0000", "CS1111"));
-        assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("12345")
+        assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }
 }

--- a/src/test/java/seedu/address/model/module/CreditsContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/module/CreditsContainsKeywordsPredicateTest.java
@@ -65,6 +65,6 @@ public class CreditsContainsKeywordsPredicateTest {
 
         // Non-matching keyword
         predicate = new CreditsContainsKeywordsPredicate(Arrays.asList("144"));
-        assertFalse(predicate.test(new ModuleBuilder().withCredits("1444").build()));
+        assertFalse(predicate.test(new ModuleBuilder().withCredits("441").build()));
     }
 }

--- a/src/test/java/seedu/address/model/module/CreditsTest.java
+++ b/src/test/java/seedu/address/model/module/CreditsTest.java
@@ -28,14 +28,19 @@ public class CreditsTest {
         // invalid credits
         assertFalse(Credits.isValidCredits("")); // empty string
         assertFalse(Credits.isValidCredits(" ")); // spaces only
-        assertFalse(Credits.isValidCredits("91")); // less than 3 numbers
-        assertFalse(Credits.isValidCredits("credits")); // non-numeric
-        assertFalse(Credits.isValidCredits("9011p041")); // alphabets within digits
-        assertFalse(Credits.isValidCredits("9312 1534")); // spaces within digits
+        assertFalse(Credits.isValidCredits("+10")); // no plus sign
+        assertFalse(Credits.isValidCredits("-1")); // no negative sign
+        assertFalse(Credits.isValidCredits("00")); // no leading zero (for 1 zero)
+        assertFalse(Credits.isValidCredits("000")); // no leading zeroes (for 1 zero)
+        assertFalse(Credits.isValidCredits("01")); // no leading zero (for 1 digit)
+        assertFalse(Credits.isValidCredits("001")); // no leading zeroes (for 1 digit)
+        assertFalse(Credits.isValidCredits("099")); // no leading zero (for 2 digits)
+        assertFalse(Credits.isValidCredits("1MC")); // alphabets within digits
+        assertFalse(Credits.isValidCredits("1 6")); // spaces within digits
 
         // valid credits
-        assertTrue(Credits.isValidCredits("911")); // exactly 3 numbers
-        assertTrue(Credits.isValidCredits("93121534"));
-        assertTrue(Credits.isValidCredits("124293842033123")); // long numbers
+        assertTrue(Credits.isValidCredits("0")); // exactly zero
+        assertTrue(Credits.isValidCredits("50")); // exactly 2 numbers
+        assertTrue(Credits.isValidCredits("999")); // exactly 3 numbers
     }
 }

--- a/src/test/java/seedu/address/model/module/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/module/NameContainsKeywordsPredicateTest.java
@@ -69,7 +69,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match credits and code, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "Main", "Street"));
-        assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("12345")
+        assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }
 }

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -16,7 +16,7 @@ import seedu.address.model.util.SampleDataUtil;
 public class ModuleBuilder {
 
     public static final String DEFAULT_NAME = "Alice Pauline";
-    public static final String DEFAULT_CREDITS = "85355255";
+    public static final String DEFAULT_CREDITS = "666";
     public static final String DEFAULT_CODE = "CS1010";
 
     private Name name;

--- a/src/test/java/seedu/address/testutil/RequirementCategoryBuilder.java
+++ b/src/test/java/seedu/address/testutil/RequirementCategoryBuilder.java
@@ -15,7 +15,7 @@ import seedu.address.model.util.SampleDataUtil;
 public class RequirementCategoryBuilder {
 
     public static final String DEFAULT_NAME = "Computing Foundation";
-    public static final String DEFAULT_CREDITS = "036";
+    public static final String DEFAULT_CREDITS = "36";
 
     private Name name;
     private Credits credits;

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -25,27 +25,27 @@ public class TypicalModules {
 
     public static final Module ALICE = new ModuleBuilder().withName("Alice Pauline")
             .withCode("CS1010")
-            .withCredits("94351253")
+            .withCredits("0")
             .withTags("friends").build();
     public static final Module BENSON = new ModuleBuilder().withName("Benson Meier")
             .withCode("CS1231")
-            .withCredits("98765432")
+            .withCredits("1")
             .withTags("owesMoney", "friends").build();
-    public static final Module CARL = new ModuleBuilder().withName("Carl Kurz").withCredits("95352563")
+    public static final Module CARL = new ModuleBuilder().withName("Carl Kurz").withCredits("2")
             .withCode("CS2040C").build();
-    public static final Module DANIEL = new ModuleBuilder().withName("Daniel Meier").withCredits("87652533")
+    public static final Module DANIEL = new ModuleBuilder().withName("Daniel Meier").withCredits("3")
             .withCode("CS2100").withTags("friends").build();
-    public static final Module ELLE = new ModuleBuilder().withName("Elle Meyer").withCredits("9482224")
+    public static final Module ELLE = new ModuleBuilder().withName("Elle Meyer").withCredits("4")
             .withCode("CS2101").build();
-    public static final Module FIONA = new ModuleBuilder().withName("Fiona Kunz").withCredits("9482427")
+    public static final Module FIONA = new ModuleBuilder().withName("Fiona Kunz").withCredits("5")
             .withCode("CS2102").build();
-    public static final Module GEORGE = new ModuleBuilder().withName("George Best").withCredits("9482442")
+    public static final Module GEORGE = new ModuleBuilder().withName("George Best").withCredits("6")
             .withCode("CS2105").build();
 
     // Manually added
-    public static final Module HOON = new ModuleBuilder().withName("Hoon Meier").withCredits("8482424")
+    public static final Module HOON = new ModuleBuilder().withName("Hoon Meier").withCredits("7")
             .withCode("CS2106").build();
-    public static final Module IDA = new ModuleBuilder().withName("Ida Mueller").withCredits("8482131")
+    public static final Module IDA = new ModuleBuilder().withName("Ida Mueller").withCredits("8")
             .withCode("CS2107").build();
 
     // Manually added - Module's details found in {@code CommandTestUtil}

--- a/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
+++ b/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
@@ -15,28 +15,28 @@ public class TypicalRequirementCategories {
 
     public static final RequirementCategory COMPUTING_FOUNDATION =
             new RequirementCategoryBuilder().withName("Computing Foundation")
-                    .withCredits("036").build();
+                    .withCredits("36").build();
     public static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS =
             new RequirementCategoryBuilder().withName("Information Security Requirements")
-                    .withCredits("032").build();
+                    .withCredits("32").build();
     public static final RequirementCategory INFORMATION_SECURITY_ELECTIVES =
             new RequirementCategoryBuilder().withName("Information Security Electives")
-                    .withCredits("012").build();
+                    .withCredits("12").build();
     public static final RequirementCategory COMPUTING_BREADTH =
             new RequirementCategoryBuilder().withName("Computing Breadth")
-                    .withCredits("020").build();
+                    .withCredits("20").build();
     public static final RequirementCategory IT_PROFESSIONALISM =
             new RequirementCategoryBuilder().withName("IT Professionalism")
-                    .withCredits("008").build();
+                    .withCredits("8").build();
     public static final RequirementCategory MATHEMATICS =
             new RequirementCategoryBuilder().withName("Mathematics")
-                    .withCredits("012").build();
+                    .withCredits("12").build();
     public static final RequirementCategory GENERAL_EDUCATION =
             new RequirementCategoryBuilder().withName("General Education")
-                    .withCredits("020").build();
+                    .withCredits("20").build();
     public static final RequirementCategory UNRESTRICTED_ELECTIVES =
             new RequirementCategoryBuilder().withName("Unrestricted Electives")
-                    .withCredits("012").build();
+                    .withCredits("12").build();
 
     private TypicalRequirementCategories() {} // prevents instantiation
 

--- a/src/test/java/seedu/address/ui/ModuleListPanelTest.java
+++ b/src/test/java/seedu/address/ui/ModuleListPanelTest.java
@@ -79,7 +79,7 @@ public class ModuleListPanelTest extends GuiUnitTest {
         ObservableList<Module> backingList = FXCollections.observableArrayList();
         for (int i = 0; i < moduleCount; i++) {
             Name name = new Name(i + "a");
-            Credits credits = new Credits("000");
+            Credits credits = new Credits("999");
             Code code = new Code("CS1010");
             Module module = new Module(name, credits, code, Collections.emptySet());
             backingList.add(module);

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -126,7 +126,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
 
         /* Case: find credits of module not in address book with PREFIX_CREDITS -> 0 modules found */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_CREDITS + "99999999";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_CREDITS + "963";
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
@@ -191,40 +191,40 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
     public void multiFind() {
         /* Case: find module with name daniel, code 'CS1231' and credts '95352563'-> 3 modules return */
         String command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "95352563";
+                + PREFIX_CREDITS + "2";
         Model expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, BENSON, CARL);
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with name, code and credits in different order -> 3 modules return */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "95352563 " + PREFIX_NAME + "Daniel ";
+                + PREFIX_CREDITS + "2 " + PREFIX_NAME + "Daniel ";
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with name daniel, credits '95352563' and invalid code -> 2 modules return */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "AZ0000 "
-                + PREFIX_CREDITS + "95352563";
+                + PREFIX_CREDITS + "2";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, CARL);
         assertCommandSuccess(command, expectedModel);
 
-        /* Case: find module with valid name, code but invalid credits -> 2 modules return */
+        /* Case: find module with valid name, code and non-existent credits -> 2 modules return */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "0004";
+                + PREFIX_CREDITS + "968";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, BENSON);
         assertCommandSuccess(command, expectedModel);
 
-        /* Case: find module with valid name but invalid code and credits -> 1 modules return */
+        /* Case: find module with valid name but non-existent code and credits -> 1 modules return */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "FAS1234 "
-                + PREFIX_CREDITS + "0004";
+                + PREFIX_CREDITS + "968";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
 
-        /* Case: find module with invalid name, code and credits -> 0 modules return */
+        /* Case: find module with non-existent name, code and credits -> 0 modules return */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Programmmmming " + PREFIX_CODE + "FAS1234 "
-                + PREFIX_CREDITS + "0004";
+                + PREFIX_CREDITS + "968";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);


### PR DESCRIPTION
`Credits#VALIDATION_REGEX` accepts at least 3 digits. However, this
constraint is too strict, and in addition, also assumes that there are
at least 3 digits supplied.

Consider the following logically valid `Credits`:

    0 Credits - entered as 000 (00000....0 is accepted too)
    4 Credits - entered as 005 (00000....4 is accepted too)
   12 Credits - entered as 012 (00000...12 is accepted too)
  150 Credits - entered as 150 (00000..150 is accepted too)

This makes adding / editing `Credits` extremely unintuitive for users.
We should instead treat the following `Credits`:

    0 Credits - accepted when entered exactly as: 0
    4 Credits - accepted when entered exactly as: 4
   12 Credits - accepted when entered exactly as: 12
  150 Credits - accepted when entered exactly as: 150

In addition, because the current constraint is lax, users may enter
arbitrary and large vaues for Credits (e.g. 999999999). However, in
practice, such large values are never needed.

Let's modify and update the `Credits` restrictions by:
* accepting up to 3 numeric digits only
* rejecting values with multiple digits beginning with `0`
* update `Credits#MESSAGE_CONSTRAINTS` to reflect the new range of
  acceptable values (0 - 999)

In addition, let's also update all affected unit tests that violates the
new credits constraint.