### PR TITLE
Follow upstream master changes: upgrade TestFX dependency to 4.0.15-alpha

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ test {
 }
 
 dependencies {
-    String testFxVersion = '4.0.12-alpha'
+    String testFxVersion = '4.0.15-alpha'
     String jUnitVersion = '5.1.0'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
@@ -69,7 +69,6 @@ dependencies {
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
-    testRuntimeOnly group: 'org.testfx', name: 'testfx-internal-java9', version: testFxVersion
     testRuntimeOnly group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-9+181'
     testRuntimeOnly group:'org.junit.vintage', name:'junit-vintage-engine', version: jUnitVersion
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion


### PR DESCRIPTION
Upstream se-edu/addressbook-level4@eeaea81 upgraded TestFX dependency to
the latest stable version 4.0.15-alpha.

Let's follow and merge the changes from se-edu#981 into master branch.