### PR TITLE
Model: update `Module#isSameModule(...)`

### DIFF
--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -16,11 +16,11 @@ import seedu.address.model.tag.Tag;
 public class Module {
 
     // Identity fields
-    private final Name name;
-    private final Credits credits;
+    private final Code code;
 
     // Data fields
-    private final Code code;
+    private final Name name;
+    private final Credits credits;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
@@ -63,10 +63,7 @@ public class Module {
             return true;
         }
 
-        return otherModule != null
-                && otherModule.getCode().equals(getCode())
-                && otherModule.getCredits().equals(getCredits())
-                && otherModule.getName().equals(getName());
+        return otherModule != null && otherModule.getCode().equals(getCode());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -29,8 +29,8 @@ public class CommandTestUtil {
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_CREDITS_AMY = "0";
     public static final String VALID_CREDITS_BOB = "999";
-    public static final String VALID_CODE_AMY = "CS1010";
-    public static final String VALID_CODE_BOB = "CS1231";
+    public static final String VALID_CODE_AMY = "AAA0000A";
+    public static final String VALID_CODE_BOB = "BBB1111B";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 

--- a/src/test/java/seedu/address/model/module/ModuleTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleTest.java
@@ -38,9 +38,9 @@ public class ModuleTest {
         Module editedAlice = new ModuleBuilder(ALICE).withCredits(VALID_CREDITS_BOB).withCode(VALID_CODE_BOB).build();
         assertFalse(ALICE.isSameModule(editedAlice));
 
-        // different name -> returns false
+        // different name but same code -> returns true
         editedAlice = new ModuleBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSameModule(editedAlice));
+        assertTrue(ALICE.isSameModule(editedAlice));
 
         // same name, same code, different attributes -> returns true
         editedAlice = new ModuleBuilder(ALICE)

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -17,7 +17,7 @@ public class ModuleBuilder {
 
     public static final String DEFAULT_NAME = "Alice Pauline";
     public static final String DEFAULT_CREDITS = "666";
-    public static final String DEFAULT_CODE = "CS1010";
+    public static final String DEFAULT_CODE = "ABC1234Z";
 
     private Name name;
     private Credits credits;

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -67,18 +67,15 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, model, expectedResultMessage);
 
-        /* Case: add a module with all fields same as another module in the address book except name -> added */
+        /* Case: add a module with all fields same as another module in the address book except name -> rejected */
         toAdd = new ModuleBuilder(AMY).withName(VALID_NAME_BOB).build();
-        command = AddCommand.COMMAND_WORD + NAME_DESC_BOB + CREDITS_DESC_AMY + CODE_DESC_AMY
-                + TAG_DESC_FRIEND;
-        assertCommandSuccess(command, toAdd);
+        command = ModuleUtil.getAddCommand(toAdd);
+        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
 
-        /* Case: add a module with all fields same as another module in the address book except credits
-         * -> added
-         */
+        /* Case: add a module with all fields same as another module in the address book except credits -> rejected */
         toAdd = new ModuleBuilder(AMY).withCredits(VALID_CREDITS_BOB).build();
         command = ModuleUtil.getAddCommand(toAdd);
-        assertCommandSuccess(command, toAdd);
+        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
 
         /* Case: add to empty address book -> added */
         deleteAllModules();

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -15,8 +15,6 @@ import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_CREDITS_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -76,23 +74,19 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
         assertCommandSuccess(command, index, BOB);
 
-        /* Case: edit a module with new values same as another module's values but with different name -> edited */
+        /* Case: edit a module with new values same as another module's values but with different name -> rejected */
         assertTrue(getModel().getAddressBook().getModuleList().contains(BOB));
         index = INDEX_SECOND_MODULE;
         assertNotEquals(getModel().getFilteredModuleList().get(index.getZeroBased()), BOB);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + CREDITS_DESC_BOB
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        editedModule = new ModuleBuilder(BOB).withName(VALID_NAME_AMY).build();
-        assertCommandSuccess(command, index, editedModule);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
 
-        /* Case: edit a module with new values same as another module's values but with different credits
-         * -> edited
-         */
+        /* Case: edit a module with new values same as another module's values but with different credits -> rejected */
         index = INDEX_SECOND_MODULE;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + CREDITS_DESC_AMY
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        editedModule = new ModuleBuilder(BOB).withCredits(VALID_CREDITS_AMY).build();
-        assertCommandSuccess(command, index, editedModule);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
 
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_MODULE;


### PR DESCRIPTION
When comparing if two modules are same using `Module#isSameModule(...)`,
the equality of `Name`, `Code` and `Credits` fields are compared.

However, this comparison may be too strict, and may result in duplicate
modules being created.

e.g. `Module#isSameModule(...)` will return false for the below modules:

  Code: AA1234
  Name: Intro to ABC
  Credits: 4

  Code: AA1234
  Name: Intro to ABC
  Credits: 12

However, they are logically referring to the same module.

We should instead make `Code` the identity field, and make `Name`,
`Credits` and `Tag` data fields of `Module` objects.

Firstly, `Credits` or `Tag` should not be considered as identity fields
because their values are not unique enough.

Secondly, `Name` should not be considered as an identity field because
some modules have identical names, but refer to different modules.

For instance, the below two modules are two separate entities:

  Code: GEK1531
  Name: Cyber Security
  Credits: 4

  Code: GET1004
  Name: Cyber Security
  Credits: 4

Let's update the `Module#isSameModule(...)` equality comparison to
reflect the changes in identity fields for `Module` objects, and fix the
affected unit tests as well.