### PR TITLE
Model: make `Module` support co-requisites

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -23,15 +24,16 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "NAME "
             + PREFIX_CODE + "CODE "
             + PREFIX_CREDITS + "CREDITS "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_COREQUISITE + "COREQUISITE]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Programming Methodology "
-            + PREFIX_CODE + "CS1010 "
+            + PREFIX_NAME + "Data Structures and Algorithms "
+            + PREFIX_CODE + "CS2040C "
             + PREFIX_CREDITS + "4 "
-            + PREFIX_TAG + "programming "
-            + PREFIX_TAG + "algorithms "
-            + PREFIX_TAG + "c "
-            + PREFIX_TAG + "imperative";
+            + PREFIX_TAG + "linkedlist "
+            + PREFIX_TAG + "stack "
+            + PREFIX_TAG + "queue "
+            + PREFIX_COREQUISITE + "CS1010";
 
     public static final String MESSAGE_SUCCESS = "New module added: %1$s";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the module list";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 
 /**
@@ -37,6 +38,8 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New module added: %1$s";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the module list";
+    public static final String MESSAGE_NON_EXISTENT_COREQUISITE =
+            "The corequisite module code (%1$s) does not exists in the module list";
 
     private final Module toAdd;
 
@@ -54,6 +57,12 @@ public class AddCommand extends Command {
 
         if (model.hasModule(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+        }
+
+        for (Code corequisite : toAdd.getCorequisites()) {
+            if (!model.hasModuleCode(corequisite)) {
+                throw new CommandException(String.format(MESSAGE_NON_EXISTENT_COREQUISITE, corequisite));
+            }
         }
 
         model.addModule(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,6 +48,10 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the address book.";
+    public static final String MESSAGE_INVALID_COREQUISITE =
+            "The module code (%1$s) cannot be a co-requisite of itself!";
+    public static final String MESSAGE_NON_EXISTENT_COREQUISITE =
+            "The corequisite module code (%1$s) does not exists in the module list";
 
     private final Index index;
     private final EditModuleDescriptor editModuleDescriptor;
@@ -78,6 +82,13 @@ public class EditCommand extends Command {
 
         if (!moduleToEdit.isSameModule(editedModule) && model.hasModule(editedModule)) {
             throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+        }
+        for (Code corequisite : editedModule.getCorequisites()) {
+            if (moduleToEdit.getCode().equals(corequisite)) {
+                throw new CommandException(String.format(MESSAGE_INVALID_COREQUISITE, corequisite));
+            } else if (!model.hasModuleCode(corequisite)) {
+                throw new CommandException(String.format(MESSAGE_NON_EXISTENT_COREQUISITE, corequisite));
+            }
         }
 
         model.setModule(moduleToEdit, editedModule);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -39,7 +40,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_CODE + "CODE] "
             + "[" + PREFIX_CREDITS + "CREDITS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_COREQUISITE + "COREQUISITE]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_CREDITS + "8 ";
 
@@ -95,8 +97,9 @@ public class EditCommand extends Command {
         Credits updatedCredits = editModuleDescriptor.getCredits().orElse(moduleToEdit.getCredits());
         Code updatedCode = editModuleDescriptor.getCode().orElse(moduleToEdit.getCode());
         Set<Tag> updatedTags = editModuleDescriptor.getTags().orElse(moduleToEdit.getTags());
+        Set<Code> updatedCorequisites = editModuleDescriptor.getCorequisites().orElse(moduleToEdit.getCorequisites());
 
-        return new Module(updatedName, updatedCredits, updatedCode, updatedTags, null);
+        return new Module(updatedName, updatedCredits, updatedCode, updatedTags, updatedCorequisites);
     }
 
     @Override
@@ -126,6 +129,7 @@ public class EditCommand extends Command {
         private Credits credits;
         private Code code;
         private Set<Tag> tags;
+        private Set<Code> corequisites;
 
         public EditModuleDescriptor() {}
 
@@ -138,13 +142,14 @@ public class EditCommand extends Command {
             setCredits(toCopy.credits);
             setCode(toCopy.code);
             setTags(toCopy.tags);
+            setCorequisites(toCopy.corequisites);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, credits, code, tags);
+            return CollectionUtil.isAnyNonNull(name, credits, code, tags, corequisites);
         }
 
         public void setName(Name name) {
@@ -188,6 +193,23 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        /**
+         * Sets {@code corequisites} to this object's {@code corequisites}.
+         * A defensive copy of {@code corequisites} is used internally.
+         */
+        public void setCorequisites(Set<Code> corequisites) {
+            this.corequisites = (corequisites != null) ? new HashSet<>(corequisites) : null;
+        }
+
+        /**
+         * Returns an unmodifiable {@code Code} set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code corequisites} is null.
+         */
+        public Optional<Set<Code>> getCorequisites() {
+            return (corequisites != null) ? Optional.of(Collections.unmodifiableSet(corequisites)) : Optional.empty();
+        }
+
         @Override
         public boolean equals(Object other) {
             // short circuit if same object
@@ -206,7 +228,8 @@ public class EditCommand extends Command {
             return getName().equals(e.getName())
                     && getCredits().equals(e.getCredits())
                     && getCode().equals(e.getCode())
-                    && getTags().equals(e.getTags());
+                    && getTags().equals(e.getTags())
+                    && getCorequisites().equals(e.getCorequisites());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -96,7 +96,7 @@ public class EditCommand extends Command {
         Code updatedCode = editModuleDescriptor.getCode().orElse(moduleToEdit.getCode());
         Set<Tag> updatedTags = editModuleDescriptor.getTags().orElse(moduleToEdit.getTags());
 
-        return new Module(updatedName, updatedCredits, updatedCode, updatedTags);
+        return new Module(updatedName, updatedCredits, updatedCode, updatedTags, null);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -41,7 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Module module = new Module(name, credits, code, tagList);
+        Module module = new Module(name, credits, code, tagList, null);
 
         return new AddCommand(module);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -29,7 +30,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG,
+                        PREFIX_COREQUISITE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -40,8 +42,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Credits credits = ParserUtil.parseCredits(argMultimap.getValue(PREFIX_CREDITS).get());
         Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Code> corequisiteList = ParserUtil.parseCorequisites(argMultimap.getAllValues(PREFIX_COREQUISITE));
 
-        Module module = new Module(name, credits, code, tagList, null);
+        Module module = new Module(name, credits, code, tagList, corequisiteList);
 
         return new AddCommand(module);
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,5 +10,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_CODE = new Prefix("code/");
     public static final Prefix PREFIX_CREDITS = new Prefix("credits/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/");
+    public static final Prefix PREFIX_COREQUISITE = new Prefix("coreq/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -16,6 +17,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditModuleDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -31,7 +33,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG,
+                        PREFIX_COREQUISITE);
 
         Index index;
 
@@ -52,6 +55,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             editModuleDescriptor.setCode(ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editModuleDescriptor::setTags);
+        parseCorequisitesForEdit(argMultimap.getAllValues(PREFIX_COREQUISITE))
+                .ifPresent(editModuleDescriptor::setCorequisites);
 
         if (!editModuleDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -75,4 +80,20 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
+    /**
+     * Parses {@code Collection<String> corequisites} into a {@code Set<Code>} if {@code corequisites} is non-empty.
+     * If {@code corequisites} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Code>} containing zero tags.
+     */
+    private Optional<Set<Code>> parseCorequisitesForEdit(Collection<String> corequisites) throws ParseException {
+        assert corequisites != null;
+
+        if (corequisites.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> corequisitesSet = (corequisites.size() == 1 && corequisites.contains(""))
+                ? Collections.emptySet()
+                : corequisites;
+        return Optional.of(ParserUtil.parseCorequisites(corequisitesSet));
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -177,4 +177,16 @@ public class ParserUtil {
         }
         return codeList;
     }
+
+    /**
+     * Parses {@code Collection<String> corequisites} into a {@code Set<Code>}.
+     */
+    public static Set<Code> parseCorequisites(Collection<String> corequisites) throws ParseException {
+        requireNonNull(corequisites);
+        final Set<Code> corequisitesSet = new HashSet<>();
+        for (String corequisite : corequisites) {
+            corequisitesSet.add(parseCode(corequisite));
+        }
+        return corequisitesSet;
+    }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.InvalidationListenerManager;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.UniqueModuleList;
 import seedu.address.model.requirement.RequirementCategory;
@@ -82,6 +83,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasModule(Module module) {
         requireNonNull(module);
         return modules.contains(module);
+    }
+
+    /**
+     * Returns true if a {@code Module} with the specified {@code Code} exists in the address book.
+     */
+    public boolean hasModuleCode(Code code) {
+        requireNonNull(code);
+        return modules.asUnmodifiableObservableList().stream().anyMatch((module) -> module.getCode().equals(code));
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,8 +2,10 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import javafx.beans.InvalidationListener;
 import javafx.collections.ObservableList;
@@ -120,6 +122,18 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeModule(Module key) {
         modules.remove(key);
+
+        ObservableList<Module> moduleList = modules.asUnmodifiableObservableList();
+        for (Module module : moduleList) {
+            if (module.getCorequisites().contains(key.getCode())) {
+                Set<Code> editedCorequisites = new HashSet<>(module.getCorequisites());
+                editedCorequisites.remove(key.getCode());
+
+                Module editedModule = new Module(module.getName(), module.getCredits(), module.getCode(),
+                        module.getTags(), editedCorequisites);
+                modules.setModule(module, editedModule);
+            }
+        }
         indicateModified();
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
@@ -82,6 +83,11 @@ public interface Model {
      * Returns true if a module with the same identity as {@code module} exists in the address book.
      */
     boolean hasModule(Module module);
+
+    /**
+     * Returns true if a {@code Module} with the specified {@code Code} exists in the address book.
+     */
+    boolean hasModuleCode(Code code);
 
     /**
      * Deletes the given module.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -15,6 +15,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.planner.DegreePlanner;
@@ -141,6 +142,12 @@ public class ModelManager implements Model {
     public boolean hasModule(Module module) {
         requireNonNull(module);
         return versionedAddressBook.hasModule(module);
+    }
+
+    @Override
+    public boolean hasModuleCode(Code code) {
+        requireNonNull(code);
+        return versionedAddressBook.hasModuleCode(code);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.model.tag.Tag;
 
@@ -116,7 +117,20 @@ public class Module {
                 .append(" Code: ")
                 .append(getCode())
                 .append(" Tags: ");
-        getTags().forEach(builder::append);
+
+        if (getTags().isEmpty()) {
+            builder.append("None");
+        } else {
+            getTags().forEach(builder::append);
+        }
+
+        builder.append(" Co-requisites: ");
+        if (getCorequisites().isEmpty()) {
+            builder.append("None");
+        } else {
+            builder.append(getCorequisites().stream().map(Code::toString).collect(Collectors.joining(", ")));
+        }
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -29,15 +29,12 @@ public class Module {
      * Every field must be present and not null.
      */
     public Module(Name name, Credits credits, Code code, Set<Tag> tags, Set<Code> corequisites) {
-        requireAllNonNull(name, credits, code, tags);
+        requireAllNonNull(name, credits, code, tags, corequisites);
         this.name = name;
         this.credits = credits;
         this.code = code;
         this.tags.addAll(tags);
-
-        if (corequisites != null) {
-            this.corequisites.addAll(corequisites);
-        }
+        this.corequisites.addAll(corequisites);
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -22,16 +22,21 @@ public class Module {
     private final Name name;
     private final Credits credits;
     private final Set<Tag> tags = new HashSet<>();
+    private final Set<Code> corequisites = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Module(Name name, Credits credits, Code code, Set<Tag> tags) {
+    public Module(Name name, Credits credits, Code code, Set<Tag> tags, Set<Code> corequisites) {
         requireAllNonNull(name, credits, code, tags);
         this.name = name;
         this.credits = credits;
         this.code = code;
         this.tags.addAll(tags);
+
+        if (corequisites != null) {
+            this.corequisites.addAll(corequisites);
+        }
     }
 
     public Name getName() {
@@ -52,6 +57,14 @@ public class Module {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns an immutable {@code Code} set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Code> getCorequisites() {
+        return Collections.unmodifiableSet(corequisites);
     }
 
     /**
@@ -84,13 +97,14 @@ public class Module {
         return otherModule.getName().equals(getName())
                 && otherModule.getCredits().equals(getCredits())
                 && otherModule.getCode().equals(getCode())
-                && otherModule.getTags().equals(getTags());
+                && otherModule.getTags().equals(getTags())
+                && otherModule.getCorequisites().equals(getCorequisites());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, credits, code, tags);
+        return Objects.hash(name, credits, code, tags, corequisites);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -21,35 +21,40 @@ public class SampleDataUtil {
             new Name("Programming Methodology"),
             new Credits("4"),
             new Code("CS1010"),
-            getTagSet("programming", "algorithms", "c", "imperative")
+            getTagSet("programming", "algorithms", "c", "imperative"),
+            getCodeSet()
     );
 
     private static final Module CS1231 = new Module(
             new Name("Discrete Structures"),
             new Credits("4"),
             new Code("CS1231"),
-            getTagSet("math", "logic", "proving")
+            getTagSet("math", "logic", "proving"),
+            getCodeSet()
     );
 
     private static final Module CS2040C = new Module(
             new Name("Data Structures and Algorithms"),
             new Credits("4"),
             new Code("CS2040C"),
-            getTagSet("linkedlist", "stack", "queue", "hashtable", "heap", "avltree", "graph", "sssp")
+            getTagSet("linkedlist", "stack", "queue", "hashtable", "heap", "avltree", "graph", "sssp"),
+            getCodeSet()
     );
 
     private static final Module CS2100 = new Module(
             new Name("Computer Organisation"),
             new Credits("4"),
             new Code("CS2100"),
-            getTagSet("boolean", "mips", "assembly", "circuit", "flipflop", "pipelining", "cache")
+            getTagSet("boolean", "mips", "assembly", "circuit", "flipflop", "pipelining", "cache"),
+            getCodeSet()
     );
 
     private static final Module CS2102 = new Module(
             new Name("Database Systems"),
             new Credits("4"),
             new Code("CS2102"),
-            getTagSet("database", "rdbms", "entity", "sql", "normalisation")
+            getTagSet("database", "rdbms", "entity", "sql", "normalisation"),
+            getCodeSet()
     );
 
     private static final RequirementCategory COMPUTING_FOUNDATION = new RequirementCategory(

--- a/src/main/java/seedu/address/storage/JsonAdaptedModule.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModule.java
@@ -27,18 +27,23 @@ class JsonAdaptedModule {
     private final String credits;
     private final String code;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final List<JsonAdaptedCode> corequisites = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedModule} with the given module details.
      */
     @JsonCreator
     public JsonAdaptedModule(@JsonProperty("name") String name, @JsonProperty("credits") String credits,
-            @JsonProperty("code") String code, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("code") String code, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+            @JsonProperty("corequisites") List<JsonAdaptedCode> corequisites) {
         this.name = name;
         this.credits = credits;
         this.code = code;
         if (tagged != null) {
             this.tagged.addAll(tagged);
+        }
+        if (corequisites != null) {
+            this.corequisites.addAll(corequisites);
         }
     }
 
@@ -52,6 +57,9 @@ class JsonAdaptedModule {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        corequisites.addAll(source.getCorequisites().stream()
+                .map(JsonAdaptedCode::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -63,6 +71,11 @@ class JsonAdaptedModule {
         final List<Tag> moduleTags = new ArrayList<>();
         for (JsonAdaptedTag tag : tagged) {
             moduleTags.add(tag.toModelType());
+        }
+
+        final List<Code> moduleCorequisites = new ArrayList<>();
+        for (JsonAdaptedCode corequisite : corequisites) {
+            moduleCorequisites.add(corequisite.toModelType());
         }
 
         if (name == null) {
@@ -90,7 +103,8 @@ class JsonAdaptedModule {
         final Code modelCode = new Code(code);
 
         final Set<Tag> modelTags = new HashSet<>(moduleTags);
-        return new Module(modelName, modelCredits, modelCode, modelTags, null);
+        final Set<Code> modelCorequisites = new HashSet<>(moduleCorequisites);
+        return new Module(modelName, modelCredits, modelCode, modelTags, modelCorequisites);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedModule.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModule.java
@@ -90,7 +90,7 @@ class JsonAdaptedModule {
         final Code modelCode = new Code(code);
 
         final Set<Tag> modelTags = new HashSet<>(moduleTags);
-        return new Module(modelName, modelCredits, modelCode, modelTags);
+        return new Module(modelName, modelCredits, modelCode, modelTags, null);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableModuleList.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableModuleList.java
@@ -12,6 +12,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 
 /**
@@ -21,6 +22,10 @@ import seedu.address.model.module.Module;
 class JsonSerializableModuleList {
 
     public static final String MESSAGE_DUPLICATE_MODULE = "Modules list contains duplicate module(s).";
+    public static final String MESSAGE_INVALID_COREQUISITE =
+            "The module code (%1$s) cannot be a co-requisite of itself!";
+    public static final String MESSAGE_NON_EXISTENT_COREQUISITE =
+            "The corequisite module code (%1$s) does not exists in the module list";
 
     private final List<JsonAdaptedModule> modules = new ArrayList<>();
 
@@ -53,6 +58,14 @@ class JsonSerializableModuleList {
             Module module = jsonAdaptedModule.toModelType();
             if (addressBook.hasModule(module)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_MODULE);
+            }
+
+            for (Code corequisite : module.getCorequisites()) {
+                if (module.getCode().equals(corequisite)) {
+                    throw new IllegalValueException(String.format(MESSAGE_INVALID_COREQUISITE, corequisite));
+                } else if (!addressBook.hasModuleCode(corequisite)) {
+                    throw new IllegalValueException(String.format(MESSAGE_NON_EXISTENT_COREQUISITE, corequisite));
+                }
             }
             addressBook.addModule(module);
         }

--- a/src/main/java/seedu/address/ui/ModuleCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCard.java
@@ -1,12 +1,14 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 
 /**
@@ -37,6 +39,8 @@ public class ModuleCard extends UiPart<Region> {
     @FXML
     private Label code;
     @FXML
+    private Label corequisites;
+    @FXML
     private FlowPane tags;
 
     public ModuleCard(Module module, int displayedIndex) {
@@ -46,6 +50,14 @@ public class ModuleCard extends UiPart<Region> {
         name.setText(module.getName().fullName);
         credits.setText(module.getCredits().value + " Module Credits");
         code.setText(module.getCode().value);
+
+        String corequisitesText = module.getCorequisites().stream().map(Code::toString)
+                .collect(Collectors.joining(", "));
+
+        if (corequisitesText.length() == 0) {
+            corequisitesText = "None";
+        }
+        corequisites.setText("Co-requisites: " + corequisitesText);
         module.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -29,6 +29,7 @@
       </HBox>
       <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       <Label fx:id="credits" styleClass="cell_small_label" text="\$credits" />
+      <Label fx:id="corequisites" styleClass="cell_small_label" text="\$corequisites" />
       <FlowPane fx:id="tags" />
     </VBox>
   </GridPane>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
@@ -4,36 +4,43 @@
     "name" : "Alice Pauline",
     "credits" : "0",
     "code" : "CS1010",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "corequisites": [ ]
   }, {
     "name" : "Benson Meier",
     "credits" : "1",
     "code" : "CS1231",
-    "tagged" : [ "owesMoney", "friends" ]
+    "tagged" : [ "owesMoney", "friends" ],
+    "corequisites": [ ]
   }, {
     "name" : "Carl Kurz",
     "credits" : "2",
     "code" : "CS2040C",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "corequisites": [ ]
   }, {
     "name" : "Daniel Meier",
     "credits" : "3",
     "code" : "CS2100",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "corequisites": [ ]
   }, {
     "name" : "Elle Meyer",
     "credits" : "4",
     "code" : "CS2101",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "corequisites": [ ]
   }, {
     "name" : "Fiona Kunz",
     "credits" : "5",
     "code" : "CS2102",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "corequisites": [ "CS1231" ]
   }, {
     "name" : "George Best",
     "credits" : "6",
     "code" : "CS2105",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "corequisites": [  ]
   } ]
 }

--- a/src/test/java/guitests/guihandles/ModuleCardHandle.java
+++ b/src/test/java/guitests/guihandles/ModuleCardHandle.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 
 /**
@@ -17,12 +18,14 @@ public class ModuleCardHandle extends NodeHandle<Node> {
     private static final String CODE_FIELD_ID = "#code";
     private static final String CREDITS_FIELD_ID = "#credits";
     private static final String TAGS_FIELD_ID = "#tags";
+    private static final String COREQUISITES_FIELD_ID = "#corequisites";
 
     private final Label idLabel;
     private final Label nameLabel;
     private final Label codeLabel;
     private final Label creditsLabel;
     private final List<Label> tagLabels;
+    private final Label corequisitesLabel;
 
     public ModuleCardHandle(Node cardNode) {
         super(cardNode);
@@ -38,6 +41,8 @@ public class ModuleCardHandle extends NodeHandle<Node> {
                 .stream()
                 .map(Label.class::cast)
                 .collect(Collectors.toList());
+
+        corequisitesLabel = getChildNode(COREQUISITES_FIELD_ID);
     }
 
     public String getId() {
@@ -67,6 +72,18 @@ public class ModuleCardHandle extends NodeHandle<Node> {
                 .collect(Collectors.toList());
     }
 
+    public String getCorequisites() {
+        String corequisites = corequisitesLabel.getText();
+        if (corequisites.startsWith("Co-requisites: ")) {
+            corequisites = corequisites.substring("Co-requisites: ".length());
+        }
+
+        if (corequisites.equals("None")) {
+            corequisites = "";
+        }
+        return corequisites;
+    }
+
     /**
      * Returns true if this handle contains {@code module}.
      */
@@ -75,8 +92,10 @@ public class ModuleCardHandle extends NodeHandle<Node> {
                 && getCode().equals(module.getCode().value)
                 && getCredits().equals(module.getCredits().value)
                 && getTags().equals(module.getTags().stream()
-                        .map(tag -> tag.tagName)
-                        .sorted()
-                        .collect(Collectors.toList()));
+                    .map(tag -> tag.tagName)
+                    .sorted()
+                    .collect(Collectors.toList()))
+                && getCorequisites().equals(module.getCorequisites().stream().map(Code::toString)
+                    .collect(Collectors.joining(", ")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyDegreePlannerList;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
@@ -159,6 +160,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasModule(Module module) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasModuleCode(Code code) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedModuleTest.java
@@ -28,6 +28,7 @@ public class JsonAdaptedModuleTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedCode> VALID_COREQUISITES = new ArrayList<>();
 
     @Test
     public void toModelType_validModuleDetails_returnsModule() throws Exception {
@@ -38,14 +39,15 @@ public class JsonAdaptedModuleTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedModule module =
-                new JsonAdaptedModule(INVALID_NAME, VALID_CREDITS, VALID_CODE, VALID_TAGS);
+                new JsonAdaptedModule(INVALID_NAME, VALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedModule module = new JsonAdaptedModule(null, VALID_CREDITS, VALID_CODE, VALID_TAGS);
+        JsonAdaptedModule module =
+                new JsonAdaptedModule(null, VALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
@@ -53,14 +55,14 @@ public class JsonAdaptedModuleTest {
     @Test
     public void toModelType_invalidCredits_throwsIllegalValueException() {
         JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, INVALID_CREDITS, VALID_CODE, VALID_TAGS);
+                new JsonAdaptedModule(VALID_NAME, INVALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = Credits.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
 
     @Test
     public void toModelType_nullCredits_throwsIllegalValueException() {
-        JsonAdaptedModule module = new JsonAdaptedModule(VALID_NAME, null, VALID_CODE, VALID_TAGS);
+        JsonAdaptedModule module = new JsonAdaptedModule(VALID_NAME, null, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Credits.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
@@ -68,14 +70,15 @@ public class JsonAdaptedModuleTest {
     @Test
     public void toModelType_invalidCode_throwsIllegalValueException() {
         JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, INVALID_CODE, VALID_TAGS);
+                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, INVALID_CODE, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = Code.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
 
     @Test
     public void toModelType_nullCode_throwsIllegalValueException() {
-        JsonAdaptedModule module = new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, null, VALID_TAGS);
+        JsonAdaptedModule module =
+                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, null, VALID_TAGS, VALID_COREQUISITES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Code.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
@@ -85,7 +88,7 @@ public class JsonAdaptedModuleTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, VALID_CODE, invalidTags);
+                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, VALID_CODE, invalidTags, VALID_COREQUISITES);
         Assert.assertThrows(IllegalValueException.class, module::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -74,7 +74,7 @@ public class ModuleBuilder {
     }
 
     public Module build() {
-        return new Module(name, credits, code, tags);
+        return new Module(name, credits, code, tags, null);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -23,12 +23,14 @@ public class ModuleBuilder {
     private Credits credits;
     private Code code;
     private Set<Tag> tags;
+    private Set<Code> corequisites;
 
     public ModuleBuilder() {
         name = new Name(DEFAULT_NAME);
         credits = new Credits(DEFAULT_CREDITS);
         code = new Code(DEFAULT_CODE);
         tags = new HashSet<>();
+        corequisites = new HashSet<>();
     }
 
     /**
@@ -39,6 +41,7 @@ public class ModuleBuilder {
         credits = moduleToCopy.getCredits();
         code = moduleToCopy.getCode();
         tags = new HashSet<>(moduleToCopy.getTags());
+        corequisites = new HashSet<>(moduleToCopy.getCorequisites());
     }
 
     /**
@@ -54,6 +57,14 @@ public class ModuleBuilder {
      */
     public ModuleBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code corequisites} into a {@code Set<Code>} and set it to the {@code Module} that we are building.
+     */
+    public ModuleBuilder withCorequisites(String ... corequisites) {
+        this.corequisites = SampleDataUtil.getCodeSet(corequisites);
         return this;
     }
 
@@ -74,7 +85,7 @@ public class ModuleBuilder {
     }
 
     public Module build() {
-        return new Module(name, credits, code, tags, null);
+        return new Module(name, credits, code, tags, corequisites);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -38,7 +38,7 @@ public class TypicalModules {
     public static final Module ELLE = new ModuleBuilder().withName("Elle Meyer").withCredits("4")
             .withCode("CS2101").build();
     public static final Module FIONA = new ModuleBuilder().withName("Fiona Kunz").withCredits("5")
-            .withCode("CS2102").build();
+            .withCode("CS2102").withCorequisites("CS1231").build();
     public static final Module GEORGE = new ModuleBuilder().withName("George Best").withCredits("6")
             .withCode("CS2105").build();
 

--- a/src/test/java/seedu/address/ui/ModuleListPanelTest.java
+++ b/src/test/java/seedu/address/ui/ModuleListPanelTest.java
@@ -81,7 +81,7 @@ public class ModuleListPanelTest extends GuiUnitTest {
             Name name = new Name(i + "a");
             Credits credits = new Credits("999");
             Code code = new Code("CS1010");
-            Module module = new Module(name, credits, code, Collections.emptySet());
+            Module module = new Module(name, credits, code, Collections.emptySet(), Collections.emptySet());
             backingList.add(module);
         }
         return backingList;

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -23,6 +23,7 @@ public class GuiTestAssert {
         assertEquals(expectedCard.getName(), actualCard.getName());
         assertEquals(expectedCard.getCredits(), actualCard.getCredits());
         assertEquals(expectedCard.getTags(), actualCard.getTags());
+        assertEquals(expectedCard.getCorequisites(), actualCard.getCorequisites());
     }
 
     /**


### PR DESCRIPTION
Resolves #89.

Co-requisites of a module cannot be added in the application.

However, users need to know what modules have to be taken together
(e.g. twinned modules) in the same semester.

Let's make `Module` support co-requisites by:
* updating `add` and `edit` commands
* cascading the deletion of module from other modules' co-requisites
* handle invalid co-requisite cases accordingly
* printing the list of co-requisites in UI
* save/load modules with co-requisites correctly
* cascading the changes to the unit tests