### PR TITLE
UserGuide: update 'planner_list_all'

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -318,7 +318,7 @@ Moves module CS1231 to year 1 semester 2.
 * `planner_move CS1231 y/1 s/4` +
 Moves module CS1231 to year 1 special semester 2.
 
-=== Listing degree planners: `planner_list_all` `[coming in v2.0]`
+=== Listing degree planners: `planner_list_all`
 
 Shows a list of all degree planners. +
 Format: `planner_list_all`


### PR DESCRIPTION
Currently, UserGuide states that `planner_list_all` command is not
implemented.

Let's update it by removing `[coming in v2.0]` tag.