### PR TITLE
build.gradle: add `buildJar`, update `archiveName` and dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'checkstyle'
-    id 'com.github.kt3k.coveralls' version '2.4.0'
-    id 'com.github.johnrengelman.shadow' version '2.0.3'
-    id 'org.asciidoctor.convert' version '1.5.6'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'org.asciidoctor.convert' version '1.5.8'
     id 'application'
 }
 
@@ -58,8 +58,8 @@ dependencies {
     String testFxVersion = '4.0.15-alpha'
     String jUnitVersion = '5.1.0'
 
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.8'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.9.8'
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.testfx', name: 'testfx-core', version: testFxVersion, {
@@ -75,8 +75,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveName = 'addressbook.jar'
-
+    archiveName = 'PWE.jar'
     destinationDir = file("${buildDir}/jar/")
 }
 
@@ -186,6 +185,8 @@ asciidoctor {
     sourceDir 'docs'
     outputDir "${buildDir}/docs"
 
+    dependsOn('copyStylesheets')
+
     options = [
         template_dirs: [file("${sourceDir}/templates")],
     ]
@@ -216,9 +217,10 @@ task copyStylesheets(type: Copy) {
     from "${asciidoctor.sourceDir}/stylesheets"
     into "${asciidoctor.outputDir}/html5/stylesheets"
 }
-asciidoctor.dependsOn copyStylesheets
 
 task deployOfflineDocs(type: Copy) {
+    dependsOn('asciidoctor')
+
     into('src/main/resources/docs')
 
     from ("${asciidoctor.outputDir}/html5") {
@@ -228,7 +230,16 @@ task deployOfflineDocs(type: Copy) {
     }
 }
 
-deployOfflineDocs.dependsOn asciidoctor
 processResources.dependsOn deployOfflineDocs
+
+task buildJar(type: GradleBuild) {
+    tasks = ['clean', 'deployOfflineDocs', 'shadowJar']
+}
+
+compileJava {
+    options.warnings = true
+    options.deprecation = true
+    options.compilerArgs += [ "-Xlint:cast,deprecation,divzero,rawtypes,unchecked" ]
+}
 
 defaultTasks 'clean', 'headless', 'allTests', 'coverage', 'asciidoctor'

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -44,7 +44,7 @@ public class Config {
         Config o = (Config) other;
 
         return Objects.equals(logLevel, o.logLevel)
-                && Objects.equals(userPrefsFilePath, o.userPrefsFilePath);
+                && Objects.equals(userPrefsFilePath.toAbsolutePath(), o.userPrefsFilePath.toAbsolutePath());
     }
 
     @Override
@@ -54,10 +54,13 @@ public class Config {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Current log level : " + logLevel);
-        sb.append("\nPreference file Location : " + userPrefsFilePath);
-        return sb.toString();
+        return new StringBuilder()
+                .append("Current log level : ")
+                .append(logLevel)
+                .append('\n')
+                .append("Preference file Location : ")
+                .append(Paths.get("").toAbsolutePath().relativize(userPrefsFilePath.toAbsolutePath()))
+                .toString();
     }
 
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -92,7 +92,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && addressBookFilePath.equals(o.addressBookFilePath);
+                && addressBookFilePath.toAbsolutePath().equals(o.addressBookFilePath.toAbsolutePath());
     }
 
     @Override
@@ -102,10 +102,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Gui Settings : " + guiSettings);
-        sb.append("\nLocal data file location : " + addressBookFilePath);
-        return sb.toString();
+        return new StringBuilder()
+                .append("Gui Settings : ")
+                .append(guiSettings)
+                .append('\n')
+                .append("Local data file location : ")
+                .append(Paths.get("").toAbsolutePath().relativize(addressBookFilePath.toAbsolutePath()))
+                .toString();
     }
 
 }


### PR DESCRIPTION
There are a few issues with the Gradle build script.
* Overlooked issues when building JAR file with `shadowJar`
  `shadowJar` simply bundles the `HelpWindow.html` without re-generating
  the docs first. This may cause the `Help` window of our application to
  display outdated details.

* `archiveName` is `addressbook.jar`, but should be `PWE.jar`
   Despite our User Guide mentioning `PWE.jar`, the JAR file created is
   by `shadowJar` is `addressbook.jar`. We should update the filename
   accordingly to suit our needs.

* Dependencies are out-of-date
  We should keep our dependencies up-to-date to fix bugs reported in the
  older releases of our dependencies.

* Lack of verbosity for `javac` linter warnings
  `javac` reports that the codebase used unchecked or unsafe operations.
   This may indicate potential bugs in our application.

To address these issues, let's update `build.gradle` by
* adding `buildJar` task to simplify the build process and ensuring that
  docs are regenerated first before building the JAR.
* update `archiveName` to `PWE.jar`
* update the out-of-date dependencies
* add `javac` arguments to increase verbosity of linter warnings so that
  we can fix the potential bugs

Note: After updating Jackson, `Path` objects are now deserialised as
      absolute paths, which causes some of the assertion tests to fail.
      As such, `commons/core/Config` & `model/UserPrefs` were updated
      accordingly to convert absolute paths back to relative paths so as
      to allow the assertion tests to pass again.