### PR TITLE
Storage/JsonSerializableAddressBook: address `javac` linter warnings

### DIFF
--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -28,11 +28,11 @@ public class JsonSerializableAddressBook {
         return requirementCategoryObservableList;
     }
 
-    public static Class getJsonSerializableModuleListClass() {
+    public static Class<JsonSerializableModuleList> getJsonSerializableModuleListClass() {
         return JsonSerializableModuleList.class;
     }
 
-    public static Class getJsonSerializableRequirementCategoryListClass() {
+    public static Class<JsonSerializableRequirementCategoryList> getJsonSerializableRequirementCategoryListClass() {
         return JsonSerializableRequirementCategoryList.class;
     }
 


### PR DESCRIPTION
In PR #69, `getJsonSerializableModuleListClass()` and
`getJsonSerializableRequirementCategoryListClass` returned the raw
`Class` instead of the required `Class<T>`.

As a result, the `javac` linter is unable to determine the generic class
at compile time, and thus it reported warnings of unchecked methods.

This may appear to be harmless, but it may cause runtime bugs in the
future.

Let's address the `javac` linter warnings by fixing the methods' return
values in `JsonSerializableAddressBook` class.