### PR TITLE
Bug fix for command 'requirement_add'

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RequirementAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RequirementAddCommand.java
@@ -4,9 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
 import seedu.address.model.requirement.RequirementCategory;
 
 /**
@@ -16,57 +21,70 @@ public class RequirementAddCommand extends Command {
 
     public static final String COMMAND_WORD = "requirement_add";
 
-    public static final String MESSAGE_USAGE =
-            COMMAND_WORD + ": Adds a module to a requirement category. " + "Parameters: "
-                    + PREFIX_NAME + "NAME "
-                    + "[" + PREFIX_CODE + "CODE]...\n"
-                    + "Example: " + COMMAND_WORD + " "
-                    + PREFIX_NAME
-                    + "IT Professionalism " + PREFIX_CODE + "IS4231 ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to a requirement category. "
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + "[" + PREFIX_CODE + "CODE]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "IT Professionalism "
+            + PREFIX_CODE + "IS4231 ";
 
-    public static final String MESSAGE_SUCCESS = "Module added to %1$s ";
-    public static final String MESSAGE_REQUIREMENT_CATEGORY_DOES_NOT_EXIST =
-            "The requirement category: %1$s does not exist";
-    public static final String MESSAGE_MODULE_DOES_NOT_EXIST =
-            "The module code does not exists in the module list";
-    public static final String MESSAGE_DUPLICATE_MODULE_IN_REQUIREMENT_CATEGORY =
+    public static final String MESSAGE_SUCCESS = "Module added to requirement category: %1$s ";
+    public static final String MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY =
+            "The requirement category: %1$s does not exist!";
+    public static final String MESSAGE_NONEXISTENT_CODE =
+            "The module to be added to the requirement category does not exists in the module list!";
+    public static final String MESSAGE_DUPLICATE_CODE =
             "The module has already been added to %1$s ";
 
-    private final RequirementCategory toAdd;
+    private final Name toFind;
+    private final Set<Code> toAdd = new HashSet<>();
 
     /**
      * Creates an RequirementAddCommand to add the specified {@code RequirementCategory}
      */
-    public RequirementAddCommand(RequirementCategory requirementCategory) {
-        requireNonNull(requirementCategory);
-        toAdd = requirementCategory;
+    public RequirementAddCommand(Name name, Set<Code> codeSet) {
+        requireNonNull(name);
+        requireNonNull(codeSet);
+        this.toFind = name;
+        this.toAdd.addAll(codeSet);
     }
 
     @Override public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
-        if (!model.hasRequirementCategory(toAdd)) {
-            throw new CommandException(String.format(MESSAGE_REQUIREMENT_CATEGORY_DOES_NOT_EXIST, toAdd.getName()));
-        }
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(toFind);
 
-        if (!model.doesModuleExistInApplication(toAdd, model)) {
-            throw new CommandException(MESSAGE_MODULE_DOES_NOT_EXIST);
-        }
-
-        if (model.isModuleInRequirementCategory(toAdd)) {
+        if (currentRequirementCategory == null) {
             throw new CommandException(
-                    String.format(MESSAGE_DUPLICATE_MODULE_IN_REQUIREMENT_CATEGORY, toAdd.getName()));
+                    String.format(MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY, toFind));
         }
 
-        model.addModuleToRequirementCategory(toAdd);
-        model.commitAddressBook();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()));
+        if (toAdd.stream().anyMatch(code -> !model.hasModuleCode(code))) {
+            throw new CommandException(MESSAGE_NONEXISTENT_CODE);
+        }
 
+        if (currentRequirementCategory.hasModuleCode(toAdd)) {
+            throw new CommandException(
+                    String.format(MESSAGE_DUPLICATE_CODE, toFind));
+        }
+
+        Set<Code> newCodeSet = new HashSet<>(currentRequirementCategory.getCodeSet());
+        newCodeSet.addAll(toAdd);
+
+        RequirementCategory editedRequirementCategory = new RequirementCategory(
+                toFind, currentRequirementCategory.getCredits(), newCodeSet);
+        model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toFind));
     }
 
-    @Override public boolean equals(Object other) {
+    @Override
+    public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof RequirementAddCommand // instanceof handles nulls
+                && toFind.equals(((RequirementAddCommand) other).toFind)
                 && toAdd.equals(((RequirementAddCommand) other).toAdd));
     }
+
 }

--- a/src/main/java/seedu/address/logic/parser/RequirementAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RequirementAddCommandParser.java
@@ -10,9 +10,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.RequirementAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Code;
-import seedu.address.model.module.Credits;
 import seedu.address.model.module.Name;
-import seedu.address.model.requirement.RequirementCategory;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -33,11 +31,9 @@ public class RequirementAddCommandParser {
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Credits credits = ParserUtil.parseCredits("0");
         Set<Code> codeList = ParserUtil.parseCodes(argMultimap.getAllValues(PREFIX_CODE));
 
-        RequirementCategory requirementCategory = new RequirementCategory(name, credits, codeList);
-        return new RequirementAddCommand(requirementCategory);
+        return new RequirementAddCommand(name, codeList);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -12,6 +12,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.util.InvalidationListenerManager;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.module.UniqueModuleList;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.planner.UniqueDegreePlannerList;
@@ -192,12 +193,30 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// requirement-level operations
 
     /**
-     * Returns true if an requirement with the same identity as {@code requirement} exists in the
-     * requirement.
+     * Returns true if a requirement with the name as {@code requirement} exists in the
+     * requirement list.
+     */
+    public boolean hasRequirementCategory(Name requirementCategoryName) {
+        requireNonNull(requirementCategoryName);
+        return requirementCategories.contains(requirementCategoryName);
+    }
+
+    /**
+     * Returns true if a requirement object {@code requirement} exists in the
+     * requirement list.
      */
     public boolean hasRequirementCategory(RequirementCategory requirementCategory) {
         requireNonNull(requirementCategory);
         return requirementCategories.contains(requirementCategory);
+    }
+
+    /**
+     * Returns true if an requirement with the same identity as {@code requirement} exists in the
+     * requirement.
+     */
+    public RequirementCategory getRequirementCategory(Name requirementCategoryName) {
+        requireNonNull(requirementCategoryName);
+        return requirementCategories.getRequirementCategory(requirementCategoryName);
     }
 
     /**
@@ -227,34 +246,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeRequirementCategory(RequirementCategory key) {
         requirementCategories.remove(key);
-    }
-
-    /**
-     * Adds module to the given requirement category.
-     * {@code requirementCategoryModule} must not already exist in the requirementCategoryList.
-     */
-    public void addModuleToRequirementCategory(RequirementCategory requirementCategoryModule) {
-        requireNonNull(requirementCategoryModule);
-        requirementCategories.addModuleToRequirementCategory(requirementCategoryModule);
-    }
-
-    /**
-     * Returns true if a module with the same identity as {@code requirementCategory} exists in the
-     * requirement category to be added to.
-     */
-    public boolean isModuleInRequirementCategory(RequirementCategory requirementCategory) {
-        requireNonNull(requirementCategory);
-        return requirementCategories.isModuleInRequirementCategory(requirementCategory);
-    }
-
-    /**
-     * Returns false if a module with the same identity as {@code requirementCategory} does not exists
-     * in the current moduleList.
-     */
-    //TODO refine this method to use methods in PR#91
-    public boolean doesModuleExistInApplication(RequirementCategory requirementCategory, Model model) {
-        requireNonNull(requirementCategory);
-        return requirementCategories.doesModuleExistInApplication(requirementCategory, model);
     }
 
     //// listener methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
 
@@ -204,16 +205,22 @@ public interface Model {
     ///// RequirementCategory Methods
 
     /**
-     * Returns true if a requirement with the code as {@code requirement} exists in the
+     * Returns true if a requirement with the name as {@code requirement} exists in the
+     * requirement list.
+     */
+    boolean hasRequirementCategory(Name requirementCategoryName);
+
+    /**
+     * Returns true if a requirement with the name as {@code requirement} exists in the
      * requirement list.
      */
     boolean hasRequirementCategory(RequirementCategory requirementCategory);
 
     /**
-     * Deletes the given requirement.
-     * The requirement must exist in the address book.
+     * Returns true if a requirement with the code as {@code requirement} exists in the
+     * requirement list.
      */
-    void deleteRequirementCategory(RequirementCategory target);
+    RequirementCategory getRequirementCategory(Name requirementCategoryName);
 
     /**
      * Adds the given requirement.
@@ -229,24 +236,6 @@ public interface Model {
      * requirement list.
      */
     void setRequirementCategory(RequirementCategory target, RequirementCategory editedRequirementCategory);
-
-    /**
-     * Adds module to the given requirement category.
-     * {@code requirementCategoryModule} must not already exist in the requirementCategoryList.
-     */
-    void addModuleToRequirementCategory(RequirementCategory requirementCategoryModule);
-
-    /**
-     * Returns true if a module with the same identity as {@code requirementCategory} exists in the
-     * requirement category to be added to.
-     */
-    boolean isModuleInRequirementCategory(RequirementCategory requirementCategory);
-
-    /**
-     * Returns false if a module with the same identity as {@code requirementCategory} does not exists
-     * in the current moduleList.
-     */
-    boolean doesModuleExistInApplication(RequirementCategory requirementCategory, Model model);
 
     /**
      * Returns an unmodifiable view of the filtered requirement list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -17,6 +17,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
@@ -311,13 +312,21 @@ public class ModelManager implements Model {
     //=========== RequirementCategoryList Methods =================================================================
 
     @Override
+    public boolean hasRequirementCategory(Name requirementCategoryName) {
+        requireNonNull(requirementCategoryName);
+        return versionedAddressBook.hasRequirementCategory(requirementCategoryName);
+    }
+
+    @Override
     public boolean hasRequirementCategory(RequirementCategory requirementCategory) {
         requireNonNull(requirementCategory);
         return versionedAddressBook.hasRequirementCategory(requirementCategory);
     }
 
-    @Override public void deleteRequirementCategory(RequirementCategory target) {
-        versionedAddressBook.removeRequirementCategory(target);
+    @Override
+    public RequirementCategory getRequirementCategory(Name requirementCategoryName) {
+        requireNonNull(requirementCategoryName);
+        return versionedAddressBook.getRequirementCategory(requirementCategoryName);
     }
 
     @Override public void addRequirementCategory(RequirementCategory requirementCategory) {
@@ -344,24 +353,6 @@ public class ModelManager implements Model {
     @Override
     public ReadOnlyProperty<RequirementCategory> selectedRequirementCategoryProperty() {
         return selectedRequirementCategory;
-    }
-
-    @Override
-    public void addModuleToRequirementCategory(RequirementCategory requirementCategoryModule) {
-        versionedAddressBook.addModuleToRequirementCategory(requirementCategoryModule);
-        updateFilteredRequirementCategoryList(PREDICATE_SHOW_ALL_REQUIREMENT_CATEGORIES);
-    }
-
-    @Override
-    public boolean isModuleInRequirementCategory(RequirementCategory requirementCategory) {
-        requireNonNull(requirementCategory);
-        return versionedAddressBook.isModuleInRequirementCategory(requirementCategory);
-    }
-
-    @Override
-    public boolean doesModuleExistInApplication(RequirementCategory requirementCategory, Model model) {
-        requireNonNull(requirementCategory);
-        return versionedAddressBook.doesModuleExistInApplication(requirementCategory, model);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/requirement/RequirementCategory.java
+++ b/src/main/java/seedu/address/model/requirement/RequirementCategory.java
@@ -22,16 +22,16 @@ public class RequirementCategory {
 
     // Data fields
     private final Credits credits;
-    private final Set<Code> codeList = new HashSet<>();
+    private final Set<Code> codeSet = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public RequirementCategory(Name name, Credits credits, Set<Code> codeList) {
-        requireAllNonNull(name, credits, codeList);
+    public RequirementCategory(Name name, Credits credits, Set<Code> codeSet) {
+        requireAllNonNull(name, credits, codeSet);
         this.name = name;
         this.credits = credits;
-        this.codeList.addAll(codeList);
+        this.codeSet.addAll(codeSet);
     }
 
     public Name getName() {
@@ -43,11 +43,11 @@ public class RequirementCategory {
     }
 
     /**
-     * Returns an immutable codeList set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable setCode, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public Set<Code> getCodeList() {
-        return Collections.unmodifiableSet(codeList);
+    public Set<Code> getCodeSet() {
+        return Collections.unmodifiableSet(codeSet);
     }
 
     /**
@@ -61,6 +61,13 @@ public class RequirementCategory {
 
         return otherRequirementCategory != null
                 && otherRequirementCategory.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if the current codeSet contains an equivalent code in the parameter toCheck
+     */
+    public boolean hasModuleCode(Set<Code> codeSetToCheck) {
+        return codeSetToCheck.stream().anyMatch(codeToCheck -> codeSet.contains(codeToCheck));
     }
 
     /**
@@ -80,12 +87,12 @@ public class RequirementCategory {
         RequirementCategory otherRequirementCategory = (RequirementCategory) other;
         return otherRequirementCategory.getName().equals(getName())
                 && otherRequirementCategory.getCredits().equals(getCredits())
-                && otherRequirementCategory.getCodeList().equals(getCodeList());
+                && otherRequirementCategory.getCodeSet().equals(getCodeSet());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, credits, codeList);
+        return Objects.hash(name, credits, codeSet);
     }
 
     @Override
@@ -96,7 +103,7 @@ public class RequirementCategory {
                 .append(" Credits: ")
                 .append(getCredits())
                 .append(" Module Codes: ")
-                .append(getCodeList());
+                .append(getCodeSet());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/model/requirement/UniqueRequirementCategoryList.java
+++ b/src/main/java/seedu/address/model/requirement/UniqueRequirementCategoryList.java
@@ -3,16 +3,12 @@ package seedu.address.model.requirement;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.Model;
-import seedu.address.model.module.Code;
-import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.requirement.exceptions.DuplicateRequirementCategoryException;
 import seedu.address.model.requirement.exceptions.RequirementCategoryNotFoundException;
 
@@ -40,7 +36,15 @@ public class UniqueRequirementCategoryList implements Iterable<RequirementCatego
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Returns true if the list contains an equivalent requirement as the given argument.
+     * Returns true if the list contains an equivalent Name as the given argument.
+     */
+    public boolean contains(Name toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().map(RequirementCategory::getName).anyMatch(toCheck::equals);
+    }
+
+    /**
+     * Returns true if the list contains an equivalent RequirementCategory as the given argument.
      */
     public boolean contains(RequirementCategory toCheck) {
         requireNonNull(toCheck);
@@ -48,18 +52,15 @@ public class UniqueRequirementCategoryList implements Iterable<RequirementCatego
     }
 
     /**
-     * Returns location of the requirementCategory in the internalList.
+     * Returns a RequirementCategory object of the requirementCategory in the internalList.
      */
-    public int location(RequirementCategory toCheck) {
+    public RequirementCategory getRequirementCategory(Name toCheck) {
         requireNonNull(toCheck);
-        int location = 0;
-        for (int i = 0; i < internalList.size(); i++) {
-            if (toCheck.getName().equals(internalList.get(i).getName())) {
-                location = i;
-                i = internalList.size();
-            }
-        }
-        return location;
+
+        return internalList.stream()
+                .filter(requirementCategory -> requirementCategory.getName().equals(toCheck))
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -72,70 +73,6 @@ public class UniqueRequirementCategoryList implements Iterable<RequirementCatego
             throw new DuplicateRequirementCategoryException();
         }
         internalList.add(toAdd);
-    }
-
-    /**
-     * Adds a module to a requirement category.
-     * The module must not already exist in the requirement category.
-     */
-    public void addModuleToRequirementCategory(RequirementCategory toAdd) {
-        requireNonNull(toAdd);
-        int location = location(toAdd);
-        Set<Code> currentListInRequirementCategory = internalList.get(location).getCodeList();
-        Set<Code> inputList = toAdd.getCodeList();
-
-        for (Code currentCode : currentListInRequirementCategory) {
-            inputList.add(currentCode);
-        }
-
-        RequirementCategory edited =
-                new RequirementCategory(internalList.get(location).getName(), internalList.get(location).getCredits(),
-                        inputList);
-
-        setRequirementCategory(internalList.get(location), edited);
-    }
-
-    /**
-     * Returns true if the list contains an equivalent requirement as the given argument.
-     */
-    public boolean isModuleInRequirementCategory(RequirementCategory toCheck) {
-        int location = location(toCheck);
-        Set<Code> currentList = internalList.get(location).getCodeList();
-        Set<Code> inputList = toCheck.getCodeList();
-
-        for (Code existingCode : currentList) {
-            for (Code newCode : inputList) {
-                if (existingCode.value.equals(newCode.value)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if the list contains an equivalent requirement as the given argument.
-     */
-    //TODO Refine the method so that it uses the implementation in PR #91
-    public boolean doesModuleExistInApplication(RequirementCategory toCheck, Model model) {
-        ObservableList<Module> existingModules = model.getFilteredModuleList();
-        Set<Code> inputList = toCheck.getCodeList();
-        Set<Code> outputList = new HashSet<>();
-        boolean checker = true;
-
-        for (Module existingModule : existingModules) {
-            for (Code newCode : inputList) {
-                if (existingModule.getCode().value.equals(newCode.value)) {
-                    outputList.add(newCode);
-                }
-            }
-        }
-
-        if (outputList.size() != inputList.size()) {
-            checker = false;
-        }
-
-        return checker;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedRequirementCategoryList.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRequirementCategoryList.java
@@ -46,7 +46,7 @@ public class JsonAdaptedRequirementCategoryList {
     public JsonAdaptedRequirementCategoryList(RequirementCategory source) {
         name = source.getName().fullName;
         credits = source.getCredits().value;
-        codeList.addAll(source.getCodeList().stream().map(JsonAdaptedCode::new).collect(Collectors.toList()));
+        codeList.addAll(source.getCodeSet().stream().map(JsonAdaptedCode::new).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
@@ -2,7 +2,7 @@
   "requirementCategories" : [ {
     "name" : "Computing Foundation",
     "credits" : "36",
-    "codeList" : [ ]
+    "codeList" : [ "CS2100" ]
   }, {
     "name" : "Information Security Requirements",
     "credits" : "32",

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
 import seedu.address.testutil.ModuleBuilder;
@@ -125,20 +126,24 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override public Path getDegreePlannerListFilePath() {
+        @Override
+        public Path getDegreePlannerListFilePath() {
             //ToDo: implement error check
             return null;
         }
 
-        @Override public void setDegreePlannerListFilePath(Path degreePlannerListFilePath) {
+        @Override
+        public void setDegreePlannerListFilePath(Path degreePlannerListFilePath) {
             //ToDo: implement error check
         }
 
-        @Override public Path getRequirementCategoryListFilePath() {
+        @Override
+        public Path getRequirementCategoryListFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override public void setRequirementCategoryListFilePath(Path requirementCategoryListFilePath) {
+        @Override
+        public void setRequirementCategoryListFilePath(Path requirementCategoryListFilePath) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -227,68 +232,70 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override public boolean hasDegreePlanner(DegreePlanner degreePlanner) {
+        @Override
+        public boolean hasDegreePlanner(DegreePlanner degreePlanner) {
             return false;
         }
 
-        @Override public void deleteDegreePlanner(DegreePlanner degreePlanner) {
+        @Override
+        public void deleteDegreePlanner(DegreePlanner degreePlanner) {
             //ToDo: implement AssertionError
         }
 
-        @Override public void addDegreePlanner(DegreePlanner degreePlanner) {
+        @Override
+        public void addDegreePlanner(DegreePlanner degreePlanner) {
             //ToDo: implement error check
         }
 
-        @Override public void setDegreePlanner(DegreePlanner target, DegreePlanner editedDegreePlanner) {
+        @Override
+        public void setDegreePlanner(DegreePlanner target, DegreePlanner editedDegreePlanner) {
             //ToDo: implement error check
         }
 
-        @Override public ObservableList<DegreePlanner> getFilteredDegreePlannerList() {
+        @Override
+        public ObservableList<DegreePlanner> getFilteredDegreePlannerList() {
             return null;
         }
 
-        @Override public void updateFilteredDegreePlannerList(Predicate<DegreePlanner> predicate) {
-            //ToDo: implement error check
-        }
-
-        @Override public boolean hasRequirementCategory(RequirementCategory degreePlanner) {
-            //ToDo: implement error check
-            return false;
-        }
-
-        @Override public void deleteRequirementCategory(RequirementCategory degreePlanner) {
-            //ToDo: implement AssertionError
-        }
-
-        @Override public void addRequirementCategory(RequirementCategory degreePlanner) {
-            //ToDo: implement error check
-        }
-
-        @Override public void setRequirementCategory(RequirementCategory target,
-                RequirementCategory editedDegreePlanner) {
+        @Override
+        public void updateFilteredDegreePlannerList(Predicate<DegreePlanner> predicate) {
             //ToDo: implement error check
         }
 
         @Override
-        public boolean isModuleInRequirementCategory(RequirementCategory requirementCategoryModule) {
+        public boolean hasRequirementCategory(Name requirementCategoryName) {
             return false;
         }
 
         @Override
-        public void addModuleToRequirementCategory(RequirementCategory requirementCategoryModule) {
+        public boolean hasRequirementCategory(RequirementCategory requirementCategory) {
+            return false;
+        }
+
+        @Override
+        public RequirementCategory getRequirementCategory(Name requirementCategoryName) {
+            //ToDo: implement error check
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addRequirementCategory(RequirementCategory requirementCategory) {
             //ToDo: implement error check
         }
 
         @Override
-        public boolean doesModuleExistInApplication(RequirementCategory requirementCategory, Model model) {
-            return false;
+        public void setRequirementCategory(RequirementCategory target,
+                RequirementCategory editedRequirementCategory) {
+            //ToDo: implement error check
         }
 
-        @Override public ObservableList<RequirementCategory> getFilteredRequirementCategoryList() {
+        @Override
+        public ObservableList<RequirementCategory> getFilteredRequirementCategoryList() {
             return null;
         }
 
-        @Override public void updateFilteredRequirementCategoryList(Predicate<RequirementCategory> predicate) {
+        @Override
+        public void updateFilteredRequirementCategoryList(Predicate<RequirementCategory> predicate) {
             //ToDo: implement error check
         }
 

--- a/src/test/java/seedu/address/logic/commands/RequirementAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RequirementAddCommandTest.java
@@ -19,9 +19,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.module.Code;
-import seedu.address.model.module.Credits;
 import seedu.address.model.module.Name;
-import seedu.address.model.requirement.RequirementCategory;
 import seedu.address.storage.JsonSerializableAddressBook;
 
 public class RequirementAddCommandTest {
@@ -41,16 +39,32 @@ public class RequirementAddCommandTest {
 
     @Test public void constructor_nullModule_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
-        new RequirementAddCommand(null);
+        new RequirementAddCommand(null, null);
     }
 
-    @Test public void execute_moduleToBeAddedDoesNotExist_throwsCommandException() {
+    @Test public void execute_nonExistentRequirementCategory_throwsCommandException() {
+        codeList.clear();
+        Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
+        assertCommandFailure(new RequirementAddCommand(nonExistentRequirementCategoryName, codeList),
+                model, commandHistory, String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                        nonExistentRequirementCategoryName));
+    }
+
+    @Test public void execute_nonExistentCode_throwsCommandException() {
         codeList.clear();
         codeList.add(new Code("CS2010"));
-        RequirementCategory requirementCategory =
-                new RequirementCategory(new Name("Computing Foundation"), new Credits("0"), codeList);
-        assertCommandFailure(new RequirementAddCommand(requirementCategory), model, commandHistory,
-                RequirementAddCommand.MESSAGE_MODULE_DOES_NOT_EXIST);
+        Name requirementCategoryName = new Name("Computing Foundation");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                RequirementAddCommand.MESSAGE_NONEXISTENT_CODE);
+    }
+
+    @Test public void execute_duplicateCode_throwsCommandException() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
+                        requirementCategoryName));
     }
 
 }

--- a/src/test/java/seedu/address/testutil/RequirementCategoryBuilder.java
+++ b/src/test/java/seedu/address/testutil/RequirementCategoryBuilder.java
@@ -19,12 +19,12 @@ public class RequirementCategoryBuilder {
 
     private Name name;
     private Credits credits;
-    private Set<Code> codeList;
+    private Set<Code> codeSet;
 
     public RequirementCategoryBuilder() {
         name = new Name(DEFAULT_NAME);
         credits = new Credits(DEFAULT_CREDITS);
-        codeList = new HashSet<>();
+        codeSet = new HashSet<>();
     }
 
     /**
@@ -33,7 +33,7 @@ public class RequirementCategoryBuilder {
     public RequirementCategoryBuilder(RequirementCategory requirementCategoryToCopy) {
         name = requirementCategoryToCopy.getName();
         credits = requirementCategoryToCopy.getCredits();
-        codeList = new HashSet<>(requirementCategoryToCopy.getCodeList());
+        codeSet = new HashSet<>(requirementCategoryToCopy.getCodeSet());
     }
 
     /**
@@ -45,11 +45,11 @@ public class RequirementCategoryBuilder {
     }
 
     /**
-     * Parses the {@code codeList} into a {@code Set<Code>} and set it to the {@code RequirementCategory} that we are
+     * Parses the {@code codes} into a {@code Set<Code>} and set it to the {@code RequirementCategory} that we are
      * building.
      */
-    public RequirementCategoryBuilder withCodes(Set<Code> codeList) {
-        this.codeList = SampleDataUtil.getCodeSet();
+    public RequirementCategoryBuilder withCodes(String... codes) {
+        this.codeSet = SampleDataUtil.getCodeSet(codes);
         return this;
     }
 
@@ -62,7 +62,7 @@ public class RequirementCategoryBuilder {
     }
 
     public RequirementCategory build() {
-        return new RequirementCategory(name, credits, codeList);
+        return new RequirementCategory(name, credits, codeSet);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
+++ b/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
@@ -15,7 +15,7 @@ public class TypicalRequirementCategories {
 
     public static final RequirementCategory COMPUTING_FOUNDATION =
             new RequirementCategoryBuilder().withName("Computing Foundation")
-                    .withCredits("36").build();
+                    .withCredits("36").withCodes("CS2100").build();
     public static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS =
             new RequirementCategoryBuilder().withName("Information Security Requirements")
                     .withCredits("32").build();


### PR DESCRIPTION
resolves #113 
The implementation of the `requirement_add` command has a bug where no 
more than one module code can be added to a requirement category.

The bug was caused by not creating a new `Set<Code>` variable whenever a
module code is added to a requirement category.

To fix this bug, we create a new `Set<Code>` containing both the 
existing module codes and the module code to be added. We also update 
`RequirementAddCommandParser` to pass the only data parsed instead of 
creating a new `RequirementCategory` instance.

Let's fix the bug and close issue #113 using the methods described above
and cascade the changes to the affected classes. To prevent further 
regression bugs, let's also add in additional unit tests to ensure the 
desired behavior of the `requirement_add` command.

* [1/6] [requirement: update logic of new command and checks](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/4f2a462cd41aba408cf58c5e31c704deee791e94)
* [2/6] [Update to files to reference updated methods](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/ab6a8cd593885fdb811cfcca29131fca43339bcb)
* [3/6] [RequirementAddCommand: update methods and to receive data parsed](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/f50bf6133fd68ac714417e30eba85c11b8632e0b)
* [4/6] [AddCommandTest: update to reference updated methods](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/e7d783021db8d3e6b2585a50576887c21dc5bb84)
* [5/6] [test: update on test data generated](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/3b83bef87a86c97d49c0edaa5f67ab7a1425b482)
* [6/6] [RequirementAddCommandTest: update to add in new test cases](https://github.com/CS2113-AY1819S2-T09-1/main/pull/112/commits/e799553f47ab3cc20498973acca73c450db6d6e5)