### PR TITLE
UI: update on degree planner 

### DIFF
--- a/src/main/java/seedu/address/ui/DegreePlannerCard.java
+++ b/src/main/java/seedu/address/ui/DegreePlannerCard.java
@@ -6,11 +6,9 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import javafx.scene.paint.Color;
 import seedu.address.model.planner.DegreePlanner;
 
 /**
@@ -48,21 +46,8 @@ public class DegreePlannerCard extends UiPart<Region> {
                 .collect(Collectors.toCollection(FXCollections::observableArrayList));
 
         degreePlannerListView.setItems(modules);
-        degreePlannerListView.setCellFactory((ListView<String> l) -> new StyleFormatCell());
         degreePlannerCardPane.setOnMouseClicked(null);
-        degreePlannerCardPane.setPrefHeight(85);
-    }
-
-    /**
-     * Custom {@code ListCell} that customizes a color of a {@code String}.
-     */
-    public class StyleFormatCell extends ListCell<String> {
-        @Override
-        protected void updateItem(String item, boolean empty) {
-            super.updateItem(item, empty);
-            setText(item);
-            setTextFill(Color.WHITESMOKE);
-        }
+        degreePlannerCardPane.setPrefHeight(120);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/DegreePlannerListPanel.java
+++ b/src/main/java/seedu/address/ui/DegreePlannerListPanel.java
@@ -2,7 +2,8 @@ package seedu.address.ui;
 
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.layout.FlowPane;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 
 import seedu.address.model.planner.DegreePlanner;
@@ -15,14 +16,29 @@ public class DegreePlannerListPanel extends UiPart<Region> {
     private static final String FXML = "DegreePlannerListPanel.fxml";
 
     @FXML
-    private FlowPane degreePlanners;
+    private ListView<DegreePlanner> degreePlanners;
 
     public DegreePlannerListPanel(ObservableList<DegreePlanner> degreePlannerList) {
         super(FXML);
-        degreePlanners.getChildren().clear();
-        for (DegreePlanner degreePlanner : degreePlannerList) {
-            DegreePlannerCard degreePlannerCard = new DegreePlannerCard(degreePlanner);
-            degreePlanners.getChildren().add(degreePlannerCard.getRoot());
+        degreePlanners.setItems(degreePlannerList);
+        degreePlanners.setCellFactory(listView -> new DegreePlannerViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code DegreePlanner}
+     * using a {@code DegreePlannerListCard}.
+     */
+    class DegreePlannerViewCell extends ListCell<DegreePlanner> {
+        @Override
+        protected void updateItem(DegreePlanner degreePlanner, boolean empty) {
+            super.updateItem(degreePlanner, empty);
+
+            if (empty || degreePlanner == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new DegreePlannerCard(degreePlanner).getRoot());
+            }
         }
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -116,6 +116,32 @@
     -fx-border-width: 1;
 }
 
+.plannerPane .list-cell .label {
+    -fx-font-size: 18px;
+}
+
+.plannerPane .list-cell:filled:even {
+    -fx-background-color: #3c3e3f;
+    -fx-outer-border: 2px;
+}
+
+.plannerPane .list-cell:filled:odd {
+    -fx-background-color: #404344;
+}
+
+.plannerCard .list-cell:filled {
+    -fx-text-fill: white;
+    -fx-font-size: 15px;
+}
+
+.plannerCard .list-cell:filled:even {
+    -fx-background-color: #424d51;
+}
+
+.plannerCard .list-cell:filled:odd {
+    -fx-background-color: #586063;
+}
+
 .list-cell .label {
     -fx-text-fill: white;
 }

--- a/src/main/resources/view/DegreePlannerListCard.fxml
+++ b/src/main/resources/view/DegreePlannerListCard.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane fx:id="degreePlannerCardPane" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8.0.172-ea"
+<StackPane fx:id="degreePlannerCardPane" xmlns="http://javafx.com/javafx/8.0.172-ea"
            xmlns:fx="http://javafx.com/fxml/1">
     <VBox prefHeight="200" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1">
         <HBox>
@@ -15,6 +15,6 @@
                 <Label fx:id="semester"/>
             </children>
         </HBox>
-        <ListView fx:id="degreePlannerListView" VBox.vgrow="SOMETIMES"/>
+        <ListView styleClass="plannerCard" fx:id="degreePlannerListView" VBox.vgrow="SOMETIMES"/>
     </VBox>
 </StackPane>

--- a/src/main/resources/view/DegreePlannerListPanel.fxml
+++ b/src/main/resources/view/DegreePlannerListPanel.fxml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.StackPane?>
-
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/9"
-           xmlns:fx="http://javafx.com/fxml/1">
-    <FlowPane fx:id="degreePlanners"/>
-</StackPane>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+<VBox styleClass="plannerPane" fx:id="placeHolder" xmlns="http://javafx.com/javafx/9"
+      xmlns:fx="http://javafx.com/fxml/1">
+    <ListView fx:id="degreePlanners" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -54,7 +54,7 @@
             <StackPane fx:id="moduleListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <StackPane fx:id="degreePlannerListPanelPlaceholder" prefWidth="340" >
+          <StackPane id="plannerStackPane" fx:id="degreePlannerListPanelPlaceholder" prefWidth="340" >
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>


### PR DESCRIPTION
Currently, `DegreePlannerListPanel` directly creates `DegreePlannerCard` on `FlowPane` which makes the real-time updates of contents in degree planners difficult. 

Hence, for simplicity, let's convert current implementation of `FlowPane` to `ListView`.
In addition, let's add some CSS styles for degree planner related UI so that it is easier to update them in future.

The following are the commits made:
* [1/3] [UI:DegreePlanner: convert FlowPane to ListView](https://github.com/CS2113-AY1819S2-T09-1/main/pull/114/commits/c51a2c354d8ef3d853a098596127220cd37ed7e9)
* [2/3] [UI:DegreePlanner: update DegreePlannerCard style](https://github.com/CS2113-AY1819S2-T09-1/main/pull/114/commits/a80d344091bceaae6c1704b3b415f29b950f7102)
* [3/3] [View: update degree planner related css](https://github.com/CS2113-AY1819S2-T09-1/main/pull/114/commits/a38110e5c03b5afae7f796e84eb62816c2a3313e)
