### PR TITLE
docs/UserGuide: fix repoURL

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -13,7 +13,7 @@ ifdef::env-github[]
 :note-caption: :information_source:
 :warning-caption: :warning:
 endif::[]
-:repoURL: https://github.com/cs2113-ay1819s2-t09-1/main/tree/master
+:repoURL: https://github.com/CS2113-AY1819S2-T09-1/main
 
 By: `Team T09-1`      Since: `Feb 2019`      Licence: `MIT`
 


### PR DESCRIPTION
The `repoURL` is linked to `/tree/master` of our github pages, although
this is still a valid github URL.

In our `UserGuide`, we used it to reference to `/releases` 
https://github.com/CS2113-AY1819S2-T09-1/main/blob/a74ccfc2c8302f2d04dc1b0bf522d5c25a704f93/docs/UserGuide.adoc#L34

This will result in the final URL to be invalid and thus lead to a 404
page not found.

As as result this might create confusion when our user read our user guide and
could not download our released `PWE.jar`

Let's fix #115 and update the `repoURL` to point to
`https://github.com/CS2113-AY1819S2-T09-1/main`
