### PR TITLE
UI: standardise `saveLocationStatus` path in status bar

### DIFF
--- a/src/main/java/seedu/address/ui/StatusBarFooter.java
+++ b/src/main/java/seedu/address/ui/StatusBarFooter.java
@@ -40,7 +40,8 @@ public class StatusBarFooter extends UiPart<Region> {
         super(FXML);
         addressBook.addListener(observable -> updateSyncStatus());
         syncStatus.setText(SYNC_STATUS_INITIAL);
-        saveLocationStatus.setText(Paths.get(".").resolve(saveLocation).toString());
+        saveLocationStatus.setText(Paths.get("").toAbsolutePath().relativize(
+                saveLocation.toAbsolutePath()).toString());
     }
 
     /**

--- a/src/test/java/seedu/address/ui/StatusBarFooterTest.java
+++ b/src/test/java/seedu/address/ui/StatusBarFooterTest.java
@@ -23,7 +23,7 @@ import seedu.address.model.AddressBook;
 public class StatusBarFooterTest extends GuiUnitTest {
 
     private static final Path STUB_SAVE_LOCATION = Paths.get("Stub");
-    private static final Path RELATIVE_PATH = Paths.get(".");
+    private static final Path RELATIVE_PATH = Paths.get("");
 
     private static final Clock originalClock = StatusBarFooter.getClock();
     private static final Clock injectedClock = Clock.fixed(Instant.now(), ZoneId.systemDefault());

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -300,8 +300,8 @@ public abstract class AddressBookSystemTest {
         assertEquals("", getResultDisplay().getText());
         assertListMatching(getModuleListPanel(), getModel().getFilteredModuleList());
         assertEquals(BrowserPanel.DEFAULT_PAGE, getBrowserPanel().getLoadedUrl());
-        assertEquals(Paths.get(".").resolve(testApp.getStorageSaveLocation()).toString(),
-                getStatusBarFooter().getSaveLocation());
+        assertEquals(Paths.get("").toAbsolutePath().relativize(testApp.getStorageSaveLocation().toAbsolutePath())
+                        .toString(), getStatusBarFooter().getSaveLocation());
         assertEquals(SYNC_STATUS_INITIAL, getStatusBarFooter().getSyncStatus());
     }
 


### PR DESCRIPTION
The displayed `saveLocationStatus` path does not match across different 
operating system.

For Windows operating system, the relative path of the save location is 
being displayed.

For UNIX-based operating system, the absolute path of the save location 
is being displayed.

Let's update the `StatusBarFooter#saveLocationStatus` in the constructor
to display relative path across all major operating system and cascade 
all changes in `systemtest`.