### PR TITLE
Logic: improve `FindCommand` to handle boolean expressions

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -39,6 +39,24 @@ public class StringUtil {
     }
 
     /**
+     * Compare one string with another while ignoring cases and leading/trailing spaces.
+     * @param stringA first string to compare
+     * @param stringB second string to compare with
+     * @return true if both strings are equal; false otherwise
+     */
+    public static boolean compareEqualsIgnoreCase(String stringA, String stringB) {
+        requireNonNull(stringA);
+        requireNonNull(stringB);
+
+        String preppedStringA = stringA.trim();
+        checkArgument(!preppedStringA.isEmpty(), "stringA parameter cannot be empty");
+        String preppedStringB = stringB.trim();
+        checkArgument(!preppedStringB.isEmpty(), "stringB parameter cannot be empty");
+
+        return preppedStringA.equalsIgnoreCase(preppedStringB);
+    }
+
+    /**
      * Returns a detailed message of the t, including the stack trace.
      */
     public static String getDetails(Throwable t) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -29,6 +29,9 @@ public class FindCommand extends Command {
             + "[" + PREFIX_CREDITS + "CREDITS credits ...]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Programming Methodology\n";
 
+    public static final String MESSAGE_INVALID_EXPRESSION =
+            "Invalid command format! (Filter expression is invalid) \n%1$s ";
+
     private final Predicate<Module> predicate;
 
     public FindCommand(Predicate<Module> predicate) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,6 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_AND;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_OR;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -20,14 +24,24 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all modules whose names, code or credits"
-            + " contain any of the specified keywords (case-insensitive)"
-            + " and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all modules which satisfies the expression"
+            + " of search conditions specified and displays them as a list with index numbers.\n"
             + "Parameters: "
-            + "[" + PREFIX_NAME + "NAME name...] "
-            + "[" + PREFIX_CODE + "CODE code...] "
-            + "[" + PREFIX_CREDITS + "CREDITS credits ...]\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Programming Methodology\n";
+            + "[" + PREFIX_NAME + "NAME] "
+            + "OPERATOR "
+            + "[" + PREFIX_CODE + "CODE] "
+            + "OPERATOR "
+            + "[" + PREFIX_CREDITS + "CREDITS]\n"
+            + "OPERATOR " + OPERATOR_AND + "for logical \"AND\" operation (both conditions A AND B must match)\n"
+            + "OPERATOR " + OPERATOR_OR + " for logical \"OR\" operation (either conditions A OR B must match)\n"
+            + "You can also use parenthesis to group what search conditions to evaluate first.\n"
+            + "Example 1 " + COMMAND_WORD + " " + PREFIX_NAME + "Programming " + OPERATOR_OR + " "
+            + PREFIX_NAME + "Data\n"
+            + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "Programming " + OPERATOR_AND + " "
+            + PREFIX_NAME + "Methodology\n"
+            + "Example 3: " + COMMAND_WORD + " " + PREFIX_NAME + "Programming " + OPERATOR_AND + " "
+            + OPERATOR_LEFT_BRACKET + " " + PREFIX_CODE + "CS1231 " + OPERATOR_OR + " " + PREFIX_CODE + "CS1010 "
+            + OPERATOR_RIGHT_BRACKET + " ";
 
     public static final String MESSAGE_INVALID_EXPRESSION =
             "Invalid command format! (Filter expression is invalid) \n%1$s ";

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -31,11 +31,7 @@ import seedu.address.model.module.NameContainsKeywordsPredicate;
  */
 public class BooleanExpressionParser {
 
-    private static final String LEFT_BRACKET = "(";
-    private static final String RIGHT_BRACKET = ")";
     private static final String WHITESPACE = " ";
-    private static final String BOOLEAN_OR = "||";
-    private static final String BOOLEAN_AND = "&&";
 
     private static KeywordsPredicate getKeywordsPredicate(String args) throws ParseException {
         ArgumentMultimap argMultimap =
@@ -82,7 +78,7 @@ public class BooleanExpressionParser {
             while (tokenizer.hasMoreTokens()) {
                 String currentToken = tokenizer.nextToken();
                 switch (currentToken) {
-                case LEFT_BRACKET:
+                case CliSyntax.OPERATOR_LEFT_BRACKET:
                     if (isNotExpectingLeftBracket) {
                         throw new ParseException(
                                 String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
@@ -91,15 +87,15 @@ public class BooleanExpressionParser {
                         isNotExpectingLeftBracket = false;
                     }
                     break;
-                case RIGHT_BRACKET:
+                case CliSyntax.OPERATOR_RIGHT_BRACKET:
                     while (operatorStack.peek() != Operator.LEFT_BRACKET) {
                         output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));
                     }
                     operatorStack.pop();
                     isNotExpectingLeftBracket = true;
                     break;
-                case BOOLEAN_OR: // Fallthrough
-                case BOOLEAN_AND:
+                case CliSyntax.OPERATOR_OR: // Fallthrough
+                case CliSyntax.OPERATOR_AND:
                     while (!operatorStack.isEmpty()
                             && hasHigherPrecedence(operatorStack.peek(), getOperatorFromString(currentToken))) {
                         output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -12,7 +12,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.StringTokenizer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -69,11 +68,11 @@ public class BooleanExpressionParser {
      * This parse method make use of the shunting yard algorithm to convert in-fix to post fix then evaluate
      * the expression.
      *
-     * @param args the user provided argument
+     * @param stringToTokenize the user provided argument
      * @return a composite predicate
      */
-    public static Predicate<Module> parse(String args) throws ParseException {
-        StringTokenizer tokenizer = new StringTokenizer(args);
+    public static Predicate<Module> parse(String stringToTokenize, List<Prefix> prefixes) throws ParseException {
+        BooleanExpressionTokenizer tokenizer = new BooleanExpressionTokenizer(stringToTokenize, prefixes);
 
         Deque<Predicate<Module>> output = new ArrayDeque<>();
         Deque<Operator> operatorStack = new ArrayDeque<>();

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -4,8 +4,16 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.Operator.applyOperator;
+import static seedu.address.logic.parser.Operator.getOperatorFromString;
+import static seedu.address.logic.parser.Operator.hasHigherPrecedence;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
@@ -15,6 +23,7 @@ import seedu.address.model.module.CodeContainsKeywordsPredicate;
 import seedu.address.model.module.Credits;
 import seedu.address.model.module.CreditsContainsKeywordsPredicate;
 import seedu.address.model.module.KeywordsPredicate;
+import seedu.address.model.module.Module;
 import seedu.address.model.module.Name;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
 
@@ -22,6 +31,12 @@ import seedu.address.model.module.NameContainsKeywordsPredicate;
  * Parse input string into a composite predicate.
  */
 public class BooleanExpressionParser {
+
+    private static final String LEFT_BRACKET = "(";
+    private static final String RIGHT_BRACKET = ")";
+    private static final String WHITESPACE = " ";
+    private static final String BOOLEAN_OR = "||";
+    private static final String BOOLEAN_AND = "&&";
 
     private static KeywordsPredicate getKeywordsPredicate(String args) throws ParseException {
         ArgumentMultimap argMultimap =
@@ -47,5 +62,84 @@ public class BooleanExpressionParser {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
         return predicate;
+    }
+
+    /**
+     * Parse input argument into a composite predicate.
+     * This parse method make use of the shunting yard algorithm to convert in-fix to post fix then evaluate
+     * the expression.
+     *
+     * @param args the user provided argument
+     * @return a composite predicate
+     */
+    public static Predicate<Module> parse(String args) throws ParseException {
+        StringTokenizer tokenizer = new StringTokenizer(args);
+
+        Deque<Predicate<Module>> output = new ArrayDeque<>();
+        Deque<Operator> operatorStack = new ArrayDeque<>();
+
+        try {
+            boolean isNotExpectingLeftBracket = false;
+            while (tokenizer.hasMoreTokens()) {
+                String currentToken = tokenizer.nextToken();
+                switch (currentToken) {
+                case LEFT_BRACKET:
+                    if (isNotExpectingLeftBracket) {
+                        throw new ParseException(
+                                String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+                    } else {
+                        operatorStack.push(Operator.LEFT_BRACKET);
+                        isNotExpectingLeftBracket = false;
+                    }
+                    break;
+                case RIGHT_BRACKET:
+                    while (operatorStack.peek() != Operator.LEFT_BRACKET) {
+                        output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));
+                    }
+                    operatorStack.pop();
+                    isNotExpectingLeftBracket = true;
+                    break;
+                case BOOLEAN_OR: // Fallthrough
+                case BOOLEAN_AND:
+                    while (!operatorStack.isEmpty()
+                            && hasHigherPrecedence(operatorStack.peek(), getOperatorFromString(currentToken))) {
+                        output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));
+                    }
+                    operatorStack.push(getOperatorFromString(currentToken));
+                    isNotExpectingLeftBracket = false;
+                    break;
+                default:
+                    // as ArgumentMultimap require a whitespace before the args
+                    // we will have to add a whitespace before our args without changing the code
+                    // of ArgumentMultimap.
+                    Predicate<Module> in = getKeywordsPredicate(WHITESPACE + currentToken);
+                    output.push(in);
+                    isNotExpectingLeftBracket = false;
+                    break;
+                }
+            }
+        } catch (NoSuchElementException nse) {
+            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        }
+
+        while (!operatorStack.isEmpty()) {
+            // need at least 2 inputs predicates to apply operator
+            if (output.size() >= 2) {
+                output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));
+            } else {
+                throw new ParseException(
+                        String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+            }
+        }
+
+        // Output stack cannot have more than 1 predicate after shunting yard.
+        // i.e. There is 2 predicate in an expression without a operator.
+        if (output.size() > 1) {
+            throw new ParseException(
+                    String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        }
+
+        assert output.size() == 1 : "output.size() should be 1.";
+        return output.pop();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -1,0 +1,8 @@
+package seedu.address.logic.parser;
+
+/**
+ * Parse input string into a composite predicate.
+ */
+public class BooleanExpressionParser {
+
+}

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -1,8 +1,51 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.CodeContainsKeywordsPredicate;
+import seedu.address.model.module.Credits;
+import seedu.address.model.module.CreditsContainsKeywordsPredicate;
+import seedu.address.model.module.KeywordsPredicate;
+import seedu.address.model.module.Name;
+import seedu.address.model.module.NameContainsKeywordsPredicate;
+
 /**
  * Parse input string into a composite predicate.
  */
 public class BooleanExpressionParser {
 
+    private static KeywordsPredicate getKeywordsPredicate(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
+        KeywordsPredicate predicate = null;
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String[] nameArgs = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
+            List<String> nameKeywords = ParserUtil.parseMultiNames(nameArgs).stream().map(Name::toString)
+                    .collect(Collectors.toList());
+            predicate = new NameContainsKeywordsPredicate(nameKeywords);
+        } else if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
+            String[] codeArgs = argMultimap.getValue(PREFIX_CODE).get().split("\\s+");
+            List<String> codeKeywords = ParserUtil.parseMultiCodes(codeArgs).stream().map(Code::toString)
+                    .collect(Collectors.toList());
+            predicate = new CodeContainsKeywordsPredicate(codeKeywords);
+        } else if (argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
+            String[] creditsArgs = argMultimap.getValue(PREFIX_CREDITS).get().split("\\s+");
+            List<String> creditKeywords = ParserUtil.parseMultiCredits(creditsArgs).stream()
+                    .map(Credits::toString).collect(Collectors.toList());
+            predicate = new CreditsContainsKeywordsPredicate(creditKeywords);
+        } else {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        return predicate;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionParser.java
@@ -13,17 +13,13 @@ import java.util.Deque;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.module.Code;
 import seedu.address.model.module.CodeContainsKeywordsPredicate;
-import seedu.address.model.module.Credits;
 import seedu.address.model.module.CreditsContainsKeywordsPredicate;
 import seedu.address.model.module.KeywordsPredicate;
 import seedu.address.model.module.Module;
-import seedu.address.model.module.Name;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
 
 /**
@@ -38,20 +34,14 @@ public class BooleanExpressionParser {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
         KeywordsPredicate predicate = null;
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String[] nameArgs = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
-            List<String> nameKeywords = ParserUtil.parseMultiNames(nameArgs).stream().map(Name::toString)
-                    .collect(Collectors.toList());
-            predicate = new NameContainsKeywordsPredicate(nameKeywords);
+            String nameKeyword = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).toString();
+            predicate = new NameContainsKeywordsPredicate(List.of(nameKeyword));
         } else if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
-            String[] codeArgs = argMultimap.getValue(PREFIX_CODE).get().split("\\s+");
-            List<String> codeKeywords = ParserUtil.parseMultiCodes(codeArgs).stream().map(Code::toString)
-                    .collect(Collectors.toList());
-            predicate = new CodeContainsKeywordsPredicate(codeKeywords);
+            String codeKeyword = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get()).toString();
+            predicate = new CodeContainsKeywordsPredicate(List.of(codeKeyword));
         } else if (argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
-            String[] creditsArgs = argMultimap.getValue(PREFIX_CREDITS).get().split("\\s+");
-            List<String> creditKeywords = ParserUtil.parseMultiCredits(creditsArgs).stream()
-                    .map(Credits::toString).collect(Collectors.toList());
-            predicate = new CreditsContainsKeywordsPredicate(creditKeywords);
+            String creditKeyword = ParserUtil.parseCredits(argMultimap.getValue(PREFIX_CREDITS).get()).toString();
+            predicate = new CreditsContainsKeywordsPredicate(List.of(creditKeyword));
         } else {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/BooleanExpressionTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/BooleanExpressionTokenizer.java
@@ -1,0 +1,148 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.OPERATORS;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Tokenizes command in the format of a boolean expression by extracting all arguments with {@link Prefix prefix} and
+ * {@link CliSyntax#OPERATORS boolean operators} as tokens.
+ * <br><br>
+ * This class functions differently from {@link ArgumentTokenizer} (does not use whitespace as delimiter) and
+ * {@link java.util.StringTokenizer StringTokenizer} (insufficient in extracting prefixed arguments and boolean
+ * operators), and is intended to be used by {@link BooleanExpressionParser}.
+ * <br><br>
+ * e.g. Tokenizing {@code a/A || (b/B && c/C)} where prefixes are {@code a/ b/ c/} will yield the following tokens: <br>
+ * 1. a/A <br>
+ * 2. ||  <br>
+ * 3. (   <br>
+ * 4. b/B <br>
+ * 5. &&  <br>
+ * 6. c/C <br>
+ * 7. )   <br>
+ */
+public class BooleanExpressionTokenizer {
+    private String stringToTokenize;
+    private final List<String> prefixes;
+    private final List<String> delimiters;
+
+    private Deque<String> tokens = new ArrayDeque<>();
+    private int nextTokenStartIndex = 0;
+    private int nextTokenEndIndex = 0;
+
+    /**
+     * Initializes a {@link BooleanExpressionTokenizer} that tokenizes {@code stringToTokenize} by extracting all
+     * arguments with {@link Prefix prefix} and {@link CliSyntax#OPERATORS boolean operators} as tokens.
+     * @param stringToTokenize a string to be tokenized
+     * @param prefixes         a list of prefixes to be included as delimiters
+     */
+    public BooleanExpressionTokenizer(String stringToTokenize, List<Prefix> prefixes) {
+        requireNonNull(stringToTokenize);
+        requireNonNull(prefixes);
+
+        this.stringToTokenize = stringToTokenize;
+        this.prefixes = prefixes.stream().map(Prefix::getPrefix).collect(Collectors.toList());
+        this.delimiters = Stream.concat(this.prefixes.stream(), OPERATORS.stream()).collect(Collectors.toList());
+
+        tokenizeString();
+    }
+
+    /**
+     * Tokenizes {@link #stringToTokenize} based on the {@link CliSyntax#OPERATORS boolean operators} and the specified
+     * {@link #prefixes} until there are no more tokens to be extracted.
+     * <br><br>
+     * Note: This method does not parse or validate the contents of the tokens.
+     */
+    private void tokenizeString() {
+        while (hasNextToken()) {
+            extractNextToken();
+        }
+    }
+
+    /**
+     * Tests if there are still more tokens available for extraction.<br>
+     * If this method returns {@code true}, then a subsequent call to {@link #extractNextToken()} will successfully
+     * extract the next token available.
+     * @return {@code true} if and only if there is at least one token remaining; {@code false} otherwise.
+     */
+    private boolean hasNextToken() {
+        // ensure token start/end indexes are within valid range
+        if (nextTokenStartIndex >= stringToTokenize.length() || nextTokenEndIndex >= stringToTokenize.length()) {
+            return false;
+        }
+
+        Optional<Integer> optionalNextTokenEndIndex = delimiters.stream()
+                .map(delimiter -> {
+                    int index = stringToTokenize.indexOf(delimiter, nextTokenStartIndex);
+                    if (index == nextTokenStartIndex) {
+                        index += delimiter.length();
+                    }
+                    return index;
+                })
+                .filter(index -> index != -1) // exclude -1 (indicates delimiter does not exists)
+                .min(Integer::compare); // get the smallest end index for next token
+
+        if (!optionalNextTokenEndIndex.isPresent()) {
+            nextTokenEndIndex = stringToTokenize.length();
+            return nextTokenStartIndex != nextTokenEndIndex;
+        } else {
+            nextTokenEndIndex = optionalNextTokenEndIndex.get();
+            return true;
+        }
+    }
+
+    /**
+     * Extracts the next available trimmed token, and adds it to the {@link #tokens} if it is not empty.
+     * <br><br>
+     * However, if the last token extracted is prefixed but the next token extracted is not a delimiter, the next token
+     * extracted will be concatenated to the last token extracted.
+     */
+    private void extractNextToken() {
+        if (nextTokenStartIndex >= stringToTokenize.length() || nextTokenEndIndex > stringToTokenize.length()) {
+            return;
+        }
+
+        String nextToken = stringToTokenize.substring(nextTokenStartIndex, nextTokenEndIndex).trim();
+        if (!nextToken.isEmpty()) {
+            String lastToken = tokens.peekLast();
+
+            // Checks if last token extracted is prefixed, but nextToken is not delimiter
+            if (!delimiters.contains(nextToken) && lastToken != null && prefixes.contains(lastToken)) {
+                // concatenate both tokens together if so, and update tokens accordingly
+                String joinnedToken = lastToken + nextToken;
+                tokens.removeLast();
+                tokens.addLast(joinnedToken);
+            } else {
+                tokens.addLast(nextToken);
+            }
+        }
+
+        nextTokenStartIndex = nextTokenEndIndex;
+    }
+
+    /**
+     * Returns the next token from this boolean expression tokenizer.
+     * @return the next token extracted
+     * @throws NoSuchElementException if there is no more tokens remaining
+     */
+    public String nextToken() throws NoSuchElementException {
+        return tokens.removeFirst();
+    }
+
+    /**
+     * Returns a boolean that indicates whether there are still tokens remaining.<br>
+     * If this method returns {@code true}, then a subsequent call to {@link #nextToken()} will successfully return a
+     * token.
+     * @return {@code true} if and only if there is at least one token remaining; {@code false} otherwise.
+     */
+    public boolean hasMoreTokens() {
+        return tokens.size() > 0;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_CREDITS = new Prefix("credits/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/");
     public static final Prefix PREFIX_COREQUISITE = new Prefix("coreq/");
+    public static final String OPERATOR_OR = "||";
+    public static final String OPERATOR_AND = "&&";
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import java.util.List;
+
 /**
  * Contains Command Line Interface (CLI) syntax definitions common to multiple commands
  */
@@ -11,7 +13,16 @@ public class CliSyntax {
     public static final Prefix PREFIX_CREDITS = new Prefix("credits/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/");
     public static final Prefix PREFIX_COREQUISITE = new Prefix("coreq/");
+
     public static final String OPERATOR_OR = "||";
     public static final String OPERATOR_AND = "&&";
+    public static final String OPERATOR_LEFT_BRACKET = "(";
+    public static final String OPERATOR_RIGHT_BRACKET = ")";
 
+    public static final List<String> OPERATORS = List.of(
+            OPERATOR_AND,
+            OPERATOR_OR,
+            OPERATOR_LEFT_BRACKET,
+            OPERATOR_RIGHT_BRACKET
+    );
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,25 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.module.Code;
-import seedu.address.model.module.CodeContainsKeywordsPredicate;
-import seedu.address.model.module.Credits;
-import seedu.address.model.module.CreditsContainsKeywordsPredicate;
-import seedu.address.model.module.KeywordsPredicate;
 import seedu.address.model.module.Module;
-import seedu.address.model.module.Name;
-import seedu.address.model.module.NameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -40,44 +27,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        Predicate<Module> predicate = getKeywordsPredicate(args);
+        Predicate<Module> predicate = BooleanExpressionParser.parse(args);
         return new FindCommand(predicate);
     }
 
-    private Predicate<Module> getKeywordsPredicate(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
-        List<KeywordsPredicate> predicates = new ArrayList<>();
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String[] nameArgs = argMultimap.getValue(PREFIX_NAME).get().split("\\s+");
-            List<String> nameKeywords = ParserUtil.parseMultiNames(nameArgs).stream().map(Name::toString)
-                    .collect(Collectors.toList());
-            predicates.add(new NameContainsKeywordsPredicate(nameKeywords));
-        }
-        if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
-            String[] codeArgs = argMultimap.getValue(PREFIX_CODE).get().split("\\s+");
-            List<String> codeKeywords = ParserUtil.parseMultiCodes(codeArgs).stream().map(Code::toString)
-                    .collect(Collectors.toList());
-            predicates.add(new CodeContainsKeywordsPredicate(codeKeywords));
-        }
-        if (argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
-            String[] creditsArgs = argMultimap.getValue(PREFIX_CREDITS).get().split("\\s+");
-            List<String> creditKeywords = ParserUtil.parseMultiCredits(creditsArgs).stream()
-                    .map(Credits::toString).collect(Collectors.toList());
-            predicates.add(new CreditsContainsKeywordsPredicate(creditKeywords));
-        }
-        if (predicates.size() == 0) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-
-        // We have to use `Predicate<Module` instead of keywordsPredicate
-        // because after predicate.or(...) this will return a Predicate<Module>
-        Predicate<Module> predicate = predicates.get(0);
-        for (int i = 1; i < predicates.size(); i++) {
-            predicate = predicate.or(predicates.get(i));
-        }
-
-        return predicate;
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,7 +2,11 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
@@ -13,6 +17,11 @@ import seedu.address.model.module.Module;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    private static final List<Prefix> PREFIXES = List.of(
+            PREFIX_NAME,
+            PREFIX_CODE,
+            PREFIX_CREDITS
+    );
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -27,7 +36,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        Predicate<Module> predicate = BooleanExpressionParser.parse(args);
+        Predicate<Module> predicate = BooleanExpressionParser.parse(args, PREFIXES);
         return new FindCommand(predicate);
     }
 

--- a/src/main/java/seedu/address/logic/parser/Operator.java
+++ b/src/main/java/seedu/address/logic/parser/Operator.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+/**
+ * Operators that can be used
+ */
+public enum Operator {
+    /*
+     We will use 99 for highest precedence, 0 for lowest precedence
+     Order of precedence
+        && > OR
+    */
+    // LEFT_BRACKET and RIGHT_BRACKET uses 1 because we handle it in our switch condition.
+    LEFT_BRACKET(0),
+    RIGHT_BRACKET(0),
+    // Boolean OR. We use 11 to indicate lower precedence
+    OR(11),
+    // Boolean AND. We use 22 to indicate a higher precedence vs boolean OR
+    // We increase more than 1 mainly for future references if there is any operators we need between them.
+    AND(22);
+    final int precedence;
+
+    Operator(int precedence) {
+        this.precedence = precedence;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/Operator.java
+++ b/src/main/java/seedu/address/logic/parser/Operator.java
@@ -4,6 +4,11 @@ import static seedu.address.logic.parser.CliSyntax.OPERATOR_AND;
 import static seedu.address.logic.parser.CliSyntax.OPERATOR_OR;
 
 import java.util.Map;
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Module;
 
 /**
  * Operators that can be used
@@ -39,5 +44,25 @@ public enum Operator {
 
     public static boolean hasHigherPrecedence(Operator op1, Operator op2) {
         return op1.precedence >= op2.precedence;
+    }
+
+    /**
+     * Apply the operator on the 2 predicate
+     *
+     * @param operator
+     * @param predicate1
+     * @param predicate2
+     * @return a composite predicate
+     */
+    public static Predicate<Module> applyOperator(Operator operator, Predicate<Module> predicate1,
+            Predicate<Module> predicate2) throws ParseException {
+        switch (operator) {
+        case OR:
+            return predicate1.or(predicate2);
+        case AND:
+            return predicate1.and(predicate2);
+        default:
+            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/Operator.java
+++ b/src/main/java/seedu/address/logic/parser/Operator.java
@@ -1,5 +1,10 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_AND;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_OR;
+
+import java.util.Map;
+
 /**
  * Operators that can be used
  */
@@ -17,9 +22,22 @@ public enum Operator {
     // Boolean AND. We use 22 to indicate a higher precedence vs boolean OR
     // We increase more than 1 mainly for future references if there is any operators we need between them.
     AND(22);
+
+    private static Map<String, Operator> ops = Map.of(
+            OPERATOR_OR, Operator.OR,
+            OPERATOR_AND, Operator.AND
+    );
     final int precedence;
 
     Operator(int precedence) {
         this.precedence = precedence;
+    }
+
+    public static Operator getOperatorFromString(String input) {
+        return ops.get(input);
+    }
+
+    public static boolean hasHigherPrecedence(Operator op1, Operator op2) {
+        return op1.precedence >= op2.precedence;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,10 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -53,25 +51,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String... name} into a {@code List<Name>}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code name} is invalid.
-     */
-    public static List<Name> parseMultiNames(String... names) throws ParseException {
-        List<Name> result = new ArrayList<>();
-        requireNonNull(names);
-        for (String name : names) {
-            String trimmedName = name.trim();
-            if (!Name.isValidName(trimmedName)) {
-                throw new ParseException(Name.MESSAGE_CONSTRAINTS);
-            }
-            result.add(new Name(trimmedName));
-        }
-        return result;
-    }
-
-    /**
      * Parses a {@code String credits} into a {@code Credits}.
      * Leading and trailing whitespaces will be trimmed.
      *
@@ -86,24 +65,6 @@ public class ParserUtil {
         return new Credits(trimmedCredits);
     }
 
-    /**
-     * Parses a {@code String... credits} into a {@code List<Credits>}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code credits} is invalid.
-     */
-    public static List<Credits> parseMultiCredits(String... credits) throws ParseException {
-        List<Credits> result = new ArrayList<>();
-        requireNonNull(credits);
-        for (String credit : credits) {
-            String trimmedCredits = credit.trim();
-            if (!Credits.isValidCredits(trimmedCredits)) {
-                throw new ParseException(Credits.MESSAGE_CONSTRAINTS);
-            }
-            result.add(new Credits(trimmedCredits));
-        }
-        return result;
-    }
 
     /**
      * Parses a {@code String code} into an {@code Code}.
@@ -118,25 +79,6 @@ public class ParserUtil {
             throw new ParseException(Code.MESSAGE_CONSTRAINTS);
         }
         return new Code(trimmedCode);
-    }
-
-    /**
-     * Parses a {@code String... code} into an {@code List<Code>}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code code} is invalid.
-     */
-    public static List<Code> parseMultiCodes(String... codes) throws ParseException {
-        List<Code> result = new ArrayList<>();
-        requireNonNull(codes);
-        for (String code : codes) {
-            String trimmedCode = code.trim();
-            if (!Code.isValidCode(trimmedCode)) {
-                throw new ParseException(Code.MESSAGE_CONSTRAINTS);
-            }
-            result.add(new Code(trimmedCode));
-        }
-        return result;
     }
 
     /**
@@ -188,5 +130,26 @@ public class ParserUtil {
             corequisitesSet.add(parseCode(corequisite));
         }
         return corequisitesSet;
+    }
+
+    /**
+     * Checks if the {@code keyword} is a word of {@code compareTo},
+     * or if {@code keyword} contain multiple words, checks whether {@code keyword} is equals to {@code compareTo}
+     * Ignore cases.
+     * If keyword do not contain any space. We will check if its part of a word.
+     * Else we check for a full match.
+     * <br>examples: <pre>
+     *     keyword = "abc"
+     *     Returns true since "abc" is part of "abc xyz 123"
+     *     keyword = "abc xyz
+     *     Returns true since "abc xyz" is equal to "abc xyz"
+     * </pre>
+     */
+    public static boolean parseKeyword(String keyword, String compareTo) {
+        if (keyword.split("\\s+").length == 1) {
+            return StringUtil.containsWordIgnoreCase(compareTo, keyword);
+        } else {
+            return StringUtil.compareEqualsIgnoreCase(compareTo, keyword);
+        }
     }
 }

--- a/src/main/java/seedu/address/model/module/CodeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/module/CodeContainsKeywordsPredicate.java
@@ -2,7 +2,7 @@ package seedu.address.model.module;
 
 import java.util.List;
 
-import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.parser.ParserUtil;
 
 /**
  * Tests that a {@code Module}'s {@code Code} matches any of the keywords given.
@@ -16,8 +16,9 @@ public class CodeContainsKeywordsPredicate implements KeywordsPredicate {
 
     @Override
     public boolean test(Module module) {
+        String moduleCode = module.getCode().toString();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.getCode().toString(), keyword));
+                .anyMatch(keyword -> ParserUtil.parseKeyword(keyword, moduleCode));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/CreditsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/module/CreditsContainsKeywordsPredicate.java
@@ -2,7 +2,7 @@ package seedu.address.model.module;
 
 import java.util.List;
 
-import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.parser.ParserUtil;
 
 /**
  * Tests that a {@code Module}'s {@code Credit} matches any of the keywords given.
@@ -16,8 +16,9 @@ public class CreditsContainsKeywordsPredicate implements KeywordsPredicate {
 
     @Override
     public boolean test(Module module) {
+        String moduleCredits = module.getCredits().toString();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.getCredits().toString(), keyword));
+                .anyMatch(keyword -> ParserUtil.parseKeyword(keyword, moduleCredits));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/module/NameContainsKeywordsPredicate.java
@@ -2,7 +2,7 @@ package seedu.address.model.module;
 
 import java.util.List;
 
-import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.parser.ParserUtil;
 
 /**
  * Tests that a {@code Module}'s {@code Name} matches any of the keywords given.
@@ -16,8 +16,9 @@ public class NameContainsKeywordsPredicate implements KeywordsPredicate {
 
     @Override
     public boolean test(Module module) {
+        String moduleName = module.getName().toString();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(module.getName().fullName, keyword));
+                .anyMatch(keyword -> ParserUtil.parseKeyword(keyword, moduleName));
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -137,6 +137,23 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    @Test
+    public void compareEqualsIgnoreCase_validInputs_correctResult() {
+
+        // empty sentence
+
+        // exact match
+        assertTrue(StringUtil.compareEqualsIgnoreCase("xyz", "xyz"));
+
+        // different cases
+        assertTrue(StringUtil.compareEqualsIgnoreCase("XyZ", "xYz"));
+        assertTrue(StringUtil.compareEqualsIgnoreCase("XYZ", "xyz"));
+
+        // with trailing spaces
+        assertTrue(StringUtil.compareEqualsIgnoreCase("        xyz", "xyz          "));
+
+    }
+
     //---------------- Tests for getDetails --------------------------------------
 
     /*

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -79,9 +78,9 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" ")));
+        List<String> keywords = Arrays.asList("foo");
+        FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " "
+                + PREFIX_NAME + "foo");
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
@@ -178,5 +178,19 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseKeyword() {
+        String keyword = "abc";
+        String actualWord = "abc xyz 123";
+        String sentence = "abc xyz";
+        assertTrue(ParserUtil.parseKeyword(keyword, actualWord));
+
+        String sentence_keyword = "abc xyz";
+        assertFalse(ParserUtil.parseKeyword(sentence_keyword, actualWord));
+
+        assertTrue(ParserUtil.parseKeyword(sentence_keyword, sentence));
+
     }
 }

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -3,6 +3,7 @@ package systemtests;
 import static org.junit.Assert.assertFalse;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_OR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -51,25 +52,29 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
 
         /* Case: find multiple modules in address book, 2 keywords -> 2 modules found */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Benson Daniel";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Benson " + OPERATOR_OR + " "
+                + PREFIX_NAME + "Daniel";
         ModelHelper.setFilteredList(expectedModel, BENSON, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple modules in address book, 2 keywords in reversed order -> 2 modules found */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel Benson";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_NAME + "Benson";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple modules in address book, 2 keywords with 1 repeat -> 2 modules found */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel Benson Daniel";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_NAME + "Benson " + OPERATOR_OR + " " + PREFIX_NAME + "Daniel";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: find multiple modules in address book, 2 matching keywords and 1 non-matching keyword
          * -> 2 modules found
          */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel Benson NonMatchingKeyWord";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_NAME + "Benson " + OPERATOR_OR + " " + PREFIX_NAME + "NonMatchingKeyWord";
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -189,42 +194,43 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
 
     @Test
     public void multiFind() {
-        /* Case: find module with name daniel, code 'CS1231' and credts '95352563'-> 3 modules return */
-        String command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "2";
+        /* Case: find module with name daniel, code 'CS1231' and credits '95352563'-> 3 modules return */
+        String command =
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " " + PREFIX_CODE + "CS1231 "
+                        + OPERATOR_OR + " " + PREFIX_CREDITS + "2";
         Model expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, BENSON, CARL);
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with name, code and credits in different order -> 3 modules return */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "2 " + PREFIX_NAME + "Daniel ";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "CS1231 " + OPERATOR_OR + " "
+                + PREFIX_CREDITS + "2 " + OPERATOR_OR + " " + PREFIX_NAME + "Daniel ";
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with name daniel, credits '95352563' and invalid code -> 2 modules return */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "AZ0000 "
-                + PREFIX_CREDITS + "2";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_CODE + "AZ0000 " + OPERATOR_OR + " " + PREFIX_CREDITS + "2";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, CARL);
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with valid name, code and non-existent credits -> 2 modules return */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "CS1231 "
-                + PREFIX_CREDITS + "968";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_CODE + "CS1231 " + OPERATOR_OR + " " + PREFIX_CREDITS + "968";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, BENSON);
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with valid name but non-existent code and credits -> 1 modules return */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + PREFIX_CODE + "FAS1234 "
-                + PREFIX_CREDITS + "968";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " "
+                + PREFIX_CODE + "FAS1234 " + OPERATOR_OR + " " + PREFIX_CREDITS + "999";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
 
         /* Case: find module with non-existent name, code and credits -> 0 modules return */
-        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Programmmmming " + PREFIX_CODE + "FAS1234 "
-                + PREFIX_CREDITS + "968";
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Programmmmming " + OPERATOR_OR + " "
+                + PREFIX_CODE + "FAS1234 " + OPERATOR_OR + " " + PREFIX_CREDITS + "999";
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -1,9 +1,13 @@
 package systemtests;
 
 import static org.junit.Assert.assertFalse;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_AND;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
 import static seedu.address.logic.parser.CliSyntax.OPERATOR_OR;
+import static seedu.address.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -194,7 +198,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
 
     @Test
     public void multiFind() {
-        /* Case: find module with name daniel, code 'CS1231' and credits '95352563'-> 3 modules return */
+        /* Case: find module with name daniel, code 'CS1231' and credits '2'-> 3 modules return */
         String command =
                 FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_OR + " " + PREFIX_CODE + "CS1231 "
                         + OPERATOR_OR + " " + PREFIX_CREDITS + "2";
@@ -234,6 +238,74 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
+    }
+
+    @Test
+    public void multiBooleanAndFind() {
+
+        /* Case: Find module name which contain both Daniel and Meier -> Return exactly 1 module
+          e.g. find ( name/Daniel && name/Meier )
+        */
+        String command = FindCommand.COMMAND_WORD + " ( " + PREFIX_NAME + "Daniel " + OPERATOR_AND + " "
+                + PREFIX_NAME + "Meier )";
+        Model expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+
+        /* Case: Find module name which contain both Daniel and Meier -> Return exactly 1 module
+          e.g. find name/Daniel && name/Meier
+        */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "Daniel " + OPERATOR_AND + " "
+                + PREFIX_NAME + "Meier";
+        expectedModel = getModel();
+        assertCommandSuccess(command, expectedModel);
+
+        /* Case: Find module code which contain CS1231 and CS2100 -> Return exactly 0 module */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "CS2100 " + OPERATOR_AND + " " + PREFIX_CODE
+                + "CS1231";
+        expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+
+        /* Case: Find module credits that are 4 and 0 -> Return exactly 0 module */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_CREDITS + "4 " + OPERATOR_AND + " " + PREFIX_CREDITS
+                + "0";
+        expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+    }
+
+    @Test
+    public void complexMultiFind() {
+        /*  find code/CS2102 || ( name/Daniel && name/Meier )  -> Return 2 modules */
+        String command =
+                FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "CS2040C" + " " + OPERATOR_OR + " "
+                        + OPERATOR_LEFT_BRACKET + PREFIX_NAME + "Daniel " + OPERATOR_AND + " "
+                        + PREFIX_NAME + "Meier " + OPERATOR_RIGHT_BRACKET;
+        Model expectedModel = getModel();
+        ModelHelper.setFilteredList(expectedModel, DANIEL, CARL);
+        assertCommandSuccess(command, expectedModel);
+    }
+
+    @Test
+    public void negativeTest() {
+        // invalid operator
+        String command = FindCommand.COMMAND_WORD + " name/Programming !! code/CS1231";
+        assertCommandFailure(command, String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        // invalid operator
+        command = FindCommand.COMMAND_WORD + " name/Programming ## code/CS1231";
+        assertCommandFailure(command, String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        // valid + invalid prefix
+        command = FindCommand.COMMAND_WORD + " name/Programming " + OPERATOR_OR + " nonExisting/CS1231";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // single invalid prefix
+        command = FindCommand.COMMAND_WORD + " nonExisting/CS1231";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // single invalid prefix with multiple white space
+        command = FindCommand.COMMAND_WORD + "                          nonExisting/CS1231                ";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+
     }
 
     /**


### PR DESCRIPTION
`FindCommandParser#getKeywordsPredicate(...)` creates a predicate that 
does an implicit boolean OR operation when combining predicates.

This may not desirable for our users as they will not be able to have 
tighter search results 
e.g. Finding for module's `name` with both `Programming` and 
`Methodology`.

We aim to improve our `FindCommand` to improve flexibility in finding 
modules easily by treating the user command arguments as a boolean 
expression.

Consider the following example.

  find name/Structures || (code/CS2040C && credits/4)

We aim to tokenize it to:
* name/Structures
* ||
* (
* code/CS2040C
* &&
* credits/4
* )

Afterwards, we apply Shunting-yard algorithm to parse and process the 
arguments accordingly.

However, `StringTokenizer` is insufficient in extracting prefixed
arguments and boolean operators, as we want to keep boolean operators as
tokens. Likewise, `ArgumentTokenizer` is also not suitable, as we do not
want to use whitespace as delimiter for splitting and extracting
arguments.

Therefore, to enable us to improve the `find` command, let's implement:
* a custom `BooleanExpressionTokenizer` to extract prefixed arguments 
  and boolean operators as tokens
* a custom `BooleanExpressionParser`` which handles the parsing of the 
  argument tokens and apply Shunting-yard algorithm
* declare the operators supported (i.e. `&&` for logical AND, || `for` 
  logical OR, () to group expression to be evaluated first
* Refactor `FindCommandParser` to utilise 
  `BooleanExpressionParser#parse(...)`
* implement and modify unit tests for the `find` command to ensure that 
  the expected behaviour is intended

This PR addresses and resolves #65, and will also fix #129.

* [ 1/14] [Logic: create `BooleanExpressionParser` class](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/bbe2af9b0876b36196c15902904757bc37d4eb43)
* [ 2/14] [Logic: create `Operator` class](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/dc39f75357e97619092dee3f43b669de4cb4a031)
* [ 3/14] [Logic: add helper method on Operator](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/6a1bbaf1847524d9e914d7cc6dd6d4c8f42518b7)
* [ 4/14] [Logic: add helper method on Operator](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/fcc701dbf43fcee9d33f2fe04cb0d38fa8451766)
* [ 5/14] [Logic: add helper method for `BooleanExpressionParser`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/b2cf5be1f24491605b8d121281771f7b5f7c781f)
* [ 6/14] [Logic: implement `BooleanExpressionParser#parse`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/165b55b7cfa3996ca5691a6cac443669ab56390f)
* [ 7/14] [Logic: utilise `BooleanExpressionParser#parse`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/cf8bd29bd127fb14ac0154b81a35e2805b83e8de)
* [ 8/14] [Logic/parser: add and use `BooleanExpressionTokenizer`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/98431c021497eb62b9d21cd07d4f868118965ad8)
* [ 9/14] [Logic: adopt `CliSyntax` for consistency](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/8d328f5147352dfbf2e7df9c6daf2c5a7a59881b)
* [10/14] [Logic: Improve `BooleanExpressionParser#getKeywordsPredicate`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/b6b35e2ce08b362c6cb29ca61a4ded2aee291c06)
* [11/14] [FindCommand: update `MESSAGE_USAGE`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/8e3af821f16a4014e66629c621615723399a2e8b)
* [12/14] [test/parser: update `ParserTest` unit test](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/377aaa302515a13ae01b8cc10522b7b3c9eb7874)
* [13/14] [systemtest/FindCommanSystemTest: fix broken unit tests](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/41dfc7bd2aded1b90d2a894144796a24110c5cfd)
* [14/14] [systemtest/FindCommanSystemTest: add unit tests](https://github.com/CS2113-AY1819S2-T09-1/main/pull/119/commits/39226387202af1fd888ec1faafe0a7c7ccce6567)