### PR TITLE
Model & Storage: add more checks to prevent edge cases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -91,7 +91,7 @@ public class EditCommand extends Command {
             }
         }
 
-        model.setModule(moduleToEdit, editedModule);
+        model.editModule(moduleToEdit, editedModule);
         model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
         model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_EDIT_MODULE_SUCCESS, editedModule));

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -109,6 +109,14 @@ public interface Model {
      * Replaces the given module {@code target} with {@code editedModule}.
      * {@code target} must exist in the address book.
      * The module identity of {@code editedModule} must not be the same as another existing module in the address book.
+     * This method also cascades changes to {@code DegreePlanner} and {@code RequirementCategory}.
+     */
+    void editModule(Module target, Module editedModule);
+
+    /**
+     * Replaces the given module {@code target} with {@code editedModule}.
+     * {@code target} must exist in the address book.
+     * The module identity of {@code editedModule} must not be the same as another existing module in the address book.
      */
     void setModule(Module target, Module editedModule);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -158,6 +158,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void editModule(Module target, Module editedModule) {
+        requireAllNonNull(target, editedModule);
+
+        versionedAddressBook.editModule(target, editedModule);
+    }
+
+    @Override
     public void setModule(Module target, Module editedModule) {
         requireAllNonNull(target, editedModule);
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.planner.DegreePlanner;
 import seedu.address.model.requirement.RequirementCategory;
@@ -11,6 +12,14 @@ import seedu.address.model.requirement.RequirementCategory;
  * A class to access the JsonSerializable files data stored as a json file on the hard disk.
  */
 public class JsonSerializableAddressBook {
+
+    public static final String MESSAGE_DUPLICATE_MODULE = "Modules list contains duplicate module(s).";
+    public static final String MESSAGE_INVALID_COREQUISITE =
+            "The module code (%1$s) cannot be a co-requisite of itself!";
+    public static final String MESSAGE_NON_EXISTENT_REQUIREMENT_CATEGORY_CODE =
+            "The module code (%1$s) in requirement category (%2$s) does not exists in the module list!";
+    public static final String MESSAGE_NON_EXISTENT_DEGREE_PLANNER_CODE =
+            "The module code (%1$s) in degree planner (Year %2$s Semester %3$s) does not exists in the module list!";
 
     private ObservableList<Module> moduleObservableList;
     private ObservableList<DegreePlanner> degreeObservableList;
@@ -58,6 +67,30 @@ public class JsonSerializableAddressBook {
         addressBook.setModules(getModuleObservableList());
         addressBook.setDegreePlanners(getDegreePlannerObservableList());
         addressBook.setRequirementCategories(getRequirementCategoryObservableList());
+
+        for (RequirementCategory requirementCategory : addressBook.getRequirementCategoryList()) {
+            for (Code code : requirementCategory.getCodeSet()) {
+                if (!addressBook.hasModuleCode(code)) {
+                    throw new IllegalValueException(String.format(MESSAGE_NON_EXISTENT_REQUIREMENT_CATEGORY_CODE,
+                            code,
+                            requirementCategory.getName()
+                    ));
+                }
+            }
+        }
+
+        for (DegreePlanner degreePlanner : addressBook.getDegreePlannerList()) {
+            for (Code code : degreePlanner.getCodes()) {
+                if (!addressBook.hasModuleCode(code)) {
+                    throw new IllegalValueException(String.format(MESSAGE_NON_EXISTENT_DEGREE_PLANNER_CODE,
+                            code,
+                            degreePlanner.getYear(),
+                            degreePlanner.getSemester()
+                    ));
+                }
+            }
+        }
+
         return addressBook;
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
@@ -11,7 +11,7 @@
     "credits" : "1",
     "code" : "CS1231",
     "tagged" : [ "owesMoney", "friends" ],
-    "corequisites": [ ]
+    "corequisites": [ "CS2102" ]
   }, {
     "name" : "Carl Kurz",
     "credits" : "2",

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -178,6 +178,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void editModule(Module target, Module editedModule) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setModule(Module target, Module editedModule) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -55,7 +55,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        expectedModel.setModule(model.getFilteredModuleList().get(0), editedModule);
+        expectedModel.editModule(model.getFilteredModuleList().get(0), editedModule);
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -77,7 +77,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.setModule(lastModule, editedModule);
+        expectedModel.editModule(lastModule, editedModule);
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -108,7 +108,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.setModule(model.getFilteredModuleList().get(0), editedModule);
+        expectedModel.editModule(model.getFilteredModuleList().get(0), editedModule);
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -169,7 +169,7 @@ public class EditCommandTest {
         EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder(editedModule).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE, descriptor);
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.setModule(moduleToEdit, editedModule);
+        expectedModel.editModule(moduleToEdit, editedModule);
         expectedModel.commitAddressBook();
 
         // edit -> first module edited
@@ -208,14 +208,15 @@ public class EditCommandTest {
      */
     @Test
     public void executeUndoRedo_validIndexFilteredList_sameModuleEdited() throws Exception {
-        Module editedModule = new ModuleBuilder().build();
+        showModuleAtIndex(model, INDEX_SECOND_MODULE);
+        Module moduleToEdit = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
+
+        Module editedModule = new ModuleBuilder().withCorequisites(moduleToEdit.getCorequisites()).build();
         EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder(editedModule).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE, descriptor);
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
-        showModuleAtIndex(model, INDEX_SECOND_MODULE);
-        Module moduleToEdit = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
-        expectedModel.setModule(moduleToEdit, editedModule);
+        expectedModel.editModule(moduleToEdit, editedModule);
         expectedModel.commitAddressBook();
 
         // edit -> edits second module in unfiltered module list / first module in filtered module list

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -125,7 +125,7 @@ public class ModelManagerTest {
         modelManager.addModule(ALICE);
         modelManager.setSelectedModule(ALICE);
         Module updatedAlice = new ModuleBuilder(ALICE).withCode(VALID_CODE_BOB).build();
-        modelManager.setModule(ALICE, updatedAlice);
+        modelManager.editModule(ALICE, updatedAlice);
         assertEquals(updatedAlice, modelManager.getSelectedModule());
     }
 

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -119,6 +119,7 @@ public class JsonAddressBookStorageTest {
         original.addModule(HOON);
         original.removeModule(ALICE);
         jsonAddressBookStorage.saveModuleList(original, moduleListFilePath);
+        jsonAddressBookStorage.saveDegreePlannerList(original, degreePlannerListFilePath);
         readBack = jsonAddressBookStorage
                 .readAddressBook(moduleListFilePath, degreePlannerListFilePath, requirementCategoryListFilePath).get();
         assertEquals(original, new AddressBook(readBack));

--- a/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditModuleDescriptorBuilder.java
@@ -72,6 +72,16 @@ public class EditModuleDescriptorBuilder {
         return this;
     }
 
+    /**
+     * Parses the {@code corequisites} into a {@code Set<Code>} and set it to the {@code EditModuleDescriptor}
+     * that we are building.
+     */
+    public EditModuleDescriptorBuilder withCorequisites(String... corequisites) {
+        Set<Code> corequisitesSet = Stream.of(corequisites).map(Code::new).collect(Collectors.toSet());
+        descriptor.setCorequisites(corequisitesSet);
+        return this;
+    }
+
     public EditCommand.EditModuleDescriptor build() {
         return descriptor;
     }

--- a/src/test/java/seedu/address/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/address/testutil/ModuleBuilder.java
@@ -69,6 +69,14 @@ public class ModuleBuilder {
     }
 
     /**
+     * Sets the {@code corequisites} of the {@code Module} that we are building.
+     */
+    public ModuleBuilder withCorequisites(Set<Code> corequisites) {
+        this.corequisites = new HashSet<>(corequisites);
+        return this;
+    }
+
+    /**
      * Sets the {@code Code} of the {@code Module} that we are building.
      */
     public ModuleBuilder withCode(String code) {

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -30,7 +30,9 @@ public class TypicalModules {
     public static final Module BENSON = new ModuleBuilder().withName("Benson Meier")
             .withCode("CS1231")
             .withCredits("1")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends")
+            .withCorequisites("CS2102")
+            .build();
     public static final Module CARL = new ModuleBuilder().withName("Carl Kurz").withCredits("2")
             .withCode("CS2040C").build();
     public static final Module DANIEL = new ModuleBuilder().withName("Daniel Meier").withCredits("3")

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -84,6 +84,7 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         selectModule(selectedIndex);
         command = DeleteCommand.COMMAND_WORD + " " + selectedIndex.getOneBased();
         deletedModule = removeModule(expectedModel, selectedIndex);
+        expectedModel.updateFilteredModuleList(Model.PREDICATE_SHOW_ALL_MODULES);
         expectedResultMessage = String.format(MESSAGE_DELETE_MODULE_SUCCESS, deletedModule);
         assertCommandSuccess(command, expectedModel, expectedResultMessage, expectedIndex);
 

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -66,7 +66,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         /* Case: redo editing the last module in the list -> last module edited again */
         command = RedoCommand.COMMAND_WORD;
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
-        model.setModule(getModel().getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased()), editedModule);
+        model.editModule(getModel().getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased()), editedModule);
         assertCommandSuccess(command, model, expectedResultMessage);
 
         /* Case: edit a module with new values same as existing values -> edited */
@@ -203,7 +203,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
     private void assertCommandSuccess(String command, Index toEdit, Module editedModule,
             Index expectedSelectedCardIndex) {
         Model expectedModel = getModel();
-        expectedModel.setModule(expectedModel.getFilteredModuleList().get(toEdit.getZeroBased()), editedModule);
+        expectedModel.editModule(expectedModel.getFilteredModuleList().get(toEdit.getZeroBased()), editedModule);
         expectedModel.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
 
         assertCommandSuccess(command, expectedModel,


### PR DESCRIPTION
De-serializing untrusted JSON files, as well as cascading changes to 
module code when they are deleted/edited may lead to edge cases.

Let's add additional logic checks to `JsonSerializable`-related classes 
and `AddressBook` to cover more edge cases, and cascade the changes to 
the affected classes.

  [1/2] Storage: add more checks in `JsonSerializable`-related classes
  [2/2] Model: add more checks in `AddressBook` class during edit/delete modules