### PR TITLE
Model & Storage: add more checks to co-requisites cascading

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -114,8 +114,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Adds a module to the address book.
      * The module must not already exist in the address book.
      */
-    public void addModule(Module p) {
-        modules.add(p);
+    public void addModule(Module moduleToAdd) {
+        modules.add(moduleToAdd);
         indicateModified();
     }
 
@@ -140,48 +140,11 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         modules.setModule(target, editedModule);
         if (!target.getCode().equals(editedModule.getCode())) {
-            cascadeEditedModuleCode(target.getCode(), editedModule.getCode());
+            cascadeEditedCodeInDegreePlanners(target.getCode(), editedModule.getCode());
+            cascadeEditedCodeInRequirementCategories(target.getCode(), editedModule.getCode());
         }
+
         indicateModified();
-    }
-
-    /**
-     * Cascades the edited module code to {@code UniqueModuleList}, {@code UniqueDegreePlannerList},
-     * and {@code UniqueRequirementCategoryList}
-     * @param codeToEdit module code to edit/find
-     * @param editedCode module code to replace with
-     */
-    private void cascadeEditedModuleCode(Code codeToEdit, Code editedCode) {
-        cascadeEditedCodeInModules(codeToEdit, editedCode);
-        cascadeEditedCodeInDegreePlanners(codeToEdit, editedCode);
-        cascadeEditedCodeInRequirementCategories(codeToEdit, editedCode);
-    }
-
-    /**
-     * Cascades the edited module code by updating {@code UniqueModuleList} accordingly
-     * @param codeToEdit module code to edit/find
-     * @param editedCode module code to replace with
-     */
-    private void cascadeEditedCodeInModules(Code codeToEdit, Code editedCode) {
-        ObservableList<Module> modules = getModuleList();
-
-        for (Module module : modules) {
-            if (module.getCorequisites().contains(codeToEdit)) {
-                Set<Code> editedCorequisiteCodes = new HashSet<>(module.getCorequisites());
-                editedCorequisiteCodes.remove(codeToEdit);
-                editedCorequisiteCodes.add(editedCode);
-
-                Module editedModule = new Module(
-                        module.getName(),
-                        module.getCredits(),
-                        module.getCode(),
-                        module.getTags(),
-                        editedCorequisiteCodes
-                );
-
-                setModule(module, editedModule);
-            }
-        }
     }
 
     /**
@@ -240,44 +203,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeModule(Module key) {
         modules.remove(key);
-        cascadeDeletedModuleCode(key.getCode());
+        cascadeDeletedCodeInDegreePlanners(key.getCode());
+        cascadeDeletedCodeInRequirementCategories(key.getCode());
         indicateModified();
-    }
-
-    /**
-     * Cascades the deleted module code to {@code UniqueModuleList}, {@code UniqueDegreePlannerList},
-     * and {@code UniqueRequirementCategoryList}.
-     * @param codeToDelete module code to delete
-     */
-    private void cascadeDeletedModuleCode(Code codeToDelete) {
-        cascadeDeletedCodeInModules(codeToDelete);
-        cascadeDeletedCodeInDegreePlanners(codeToDelete);
-        cascadeDeletedCodeInRequirementCategories(codeToDelete);
-    }
-
-    /**
-     * Cascades the deleted module code by removing it from {@code UniqueModuleList} accordingly
-     * @param codeToDelete module code to delete
-     */
-    private void cascadeDeletedCodeInModules(Code codeToDelete) {
-        ObservableList<Module> modules = getModuleList();
-
-        for (Module module : modules) {
-            if (module.getCorequisites().contains(codeToDelete)) {
-                Set<Code> editedCorequisiteCodes = new HashSet<>(module.getCorequisites());
-                editedCorequisiteCodes.remove(codeToDelete);
-
-                Module editedModule = new Module(
-                        module.getName(),
-                        module.getCredits(),
-                        module.getCode(),
-                        module.getTags(),
-                        editedCorequisiteCodes
-                );
-
-                setModule(module, editedModule);
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Let's prevent edge cases from adding additional logic checks to
`AddressBook` by cascading changes to module code when they are added,
deleted or edited, and cascade the changes to the affected classes.