### PR TITLE
Logic/commands: implement `requirement_remove` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RequirementRemoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RequirementRemoveCommand.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
+import seedu.address.model.requirement.RequirementCategory;
+
+/**
+ * Removes a module from a requirement category.
+ */
+public class RequirementRemoveCommand extends Command {
+
+    public static final String COMMAND_WORD = "requirement_remove";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes a module from a requirement category.\n"
+            + "Parameters: "
+            + PREFIX_NAME + "NAME "
+            + PREFIX_CODE + "CODE "
+            + "[" + PREFIX_CODE + "CODE]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "IT Professionalism "
+            + PREFIX_CODE + "IS4231 ";
+
+    public static final String MESSAGE_SUCCESS = "Module removed from requirement category: %1$s";
+    public static final String MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY =
+            "The requirement category (%1$s) does not exist!";
+    public static final String MESSAGE_NONEXISTENT_CODE =
+            "The module to be removed from the requirement category does not exists in the module list!";
+    public static final String MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE =
+            "The module to be removed does not exists in %1$s";
+
+    private final Name toFind;
+    private final Set<Code> toRemove = new HashSet<>();
+
+    /**
+     * Creates an RequirementRemoveCommand to add the specified {@code Name, codeSet}
+     */
+    public RequirementRemoveCommand(Name name, Set<Code> codeSet) {
+        requireNonNull(name);
+        requireNonNull(codeSet);
+        this.toFind = name;
+        this.toRemove.addAll(codeSet);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(toFind);
+
+        if (currentRequirementCategory == null) {
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY, toFind));
+        }
+
+        if (toRemove.stream().anyMatch(code -> !model.hasModuleCode(code))) {
+            throw new CommandException(MESSAGE_NONEXISTENT_CODE);
+        }
+
+        if (!currentRequirementCategory.getCodeSet().containsAll(toRemove)) {
+            throw new CommandException(String.format(MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE, toFind));
+        }
+
+        Set<Code> newCodeSet = new HashSet<>(currentRequirementCategory.getCodeSet());
+        newCodeSet.removeAll(toRemove);
+
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategory(toFind, currentRequirementCategory.getCredits(), newCodeSet);
+        model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toFind));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RequirementRemoveCommand // instanceof handles nulls
+                && toFind.equals(((RequirementRemoveCommand) other).toFind)
+                && toRemove.equals(((RequirementRemoveCommand) other).toRemove));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RequirementAddCommand;
 import seedu.address.logic.commands.RequirementListCommand;
+import seedu.address.logic.commands.RequirementRemoveCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -78,6 +79,9 @@ public class AddressBookParser {
 
         case RequirementListCommand.COMMAND_WORD:
             return new RequirementListCommand();
+
+        case RequirementRemoveCommand.COMMAND_WORD:
+            return new RequirementRemoveCommandParser().parse(arguments);
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/logic/parser/RequirementRemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RequirementRemoveCommandParser.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.RequirementRemoveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
+
+/**
+ * Parses input arguments and creates a new RequirementRemoveCommand object
+ */
+public class RequirementRemoveCommandParser implements Parser<RequirementRemoveCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the RequirementRemoveCommand
+     * and returns an RequirementRemoveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RequirementRemoveCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RequirementRemoveCommand.MESSAGE_USAGE));
+        }
+
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Set<Code> codeList = ParserUtil.parseCodes(argMultimap.getAllValues(PREFIX_CODE));
+
+        return new RequirementRemoveCommand(name, codeList);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RequirementRemoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RequirementRemoveCommandTest.java
@@ -1,0 +1,125 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static seedu.address.testutil.TypicalModules.getTypicalModuleList;
+import static seedu.address.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
+import seedu.address.model.requirement.RequirementCategory;
+import seedu.address.storage.JsonSerializableAddressBook;
+
+public class RequirementRemoveCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+    private Model model;
+    private Set<Code> codeList = new HashSet<>();
+
+    @Before
+    public void setUp() throws IllegalValueException {
+        model = new ModelManager(
+                new JsonSerializableAddressBook(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                        getTypicalRequirementCategoriesList())
+                        .toModelType(), new UserPrefs());
+    }
+
+    @Test
+    public void constructor_nullInputs_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new RequirementRemoveCommand(null, null);
+    }
+
+    @Test
+    public void execute_nonExistentRequirementCategory_throwsCommandException() {
+        codeList.clear();
+        Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
+        assertCommandFailure(new RequirementRemoveCommand(nonExistentRequirementCategoryName, codeList),
+                model, commandHistory, String.format(RequirementRemoveCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                        nonExistentRequirementCategoryName));
+    }
+
+    @Test
+    public void execute_nonExistentCode_throwsCommandException() {
+        codeList.clear();
+        codeList.add(new Code("CS9999"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+        assertCommandFailure(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
+                RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE);
+    }
+
+    @Test
+    public void execute_duplicateCode_throwsCommandException() {
+        codeList.clear();
+        codeList.add(new Code("CS1010"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+        assertCommandFailure(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementRemoveCommand.MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE,
+                        requirementCategoryName));
+    }
+
+    @Test
+    public void execute_addModuleToRequirementCategory_success() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+
+        Model expectedModel = model;
+        expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementRemoveCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
+                expectedModel);
+    }
+
+    @Test
+    public void execute_equals() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+
+        Set<Code> codeListToCompare = new HashSet<>();
+        codeListToCompare.add(new Code("CS1010"));
+        Name requirementCategoryNameToCompare = new Name("Mathematics");
+
+        RequirementRemoveCommand commandBaseline = new RequirementRemoveCommand(requirementCategoryName, codeList);
+        RequirementRemoveCommand commandToCompare =
+                new RequirementRemoveCommand(requirementCategoryNameToCompare, codeListToCompare);
+
+        //same object -> returns true
+        assertTrue(commandBaseline.equals(commandBaseline));
+
+        //different objects, same values -> returns true
+        RequirementRemoveCommand commandBaselineCopy = new RequirementRemoveCommand(requirementCategoryName, codeList);
+        assertTrue(commandBaseline.equals(commandBaselineCopy));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(commandToCompare));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(1));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -11,7 +11,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,17 +33,20 @@ import seedu.address.logic.commands.PlannerListAllCommand;
 import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RequirementListCommand;
+import seedu.address.logic.commands.RequirementRemoveCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.Name;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
 import seedu.address.model.planner.Semester;
 import seedu.address.model.planner.Year;
 import seedu.address.testutil.EditModuleDescriptorBuilder;
 import seedu.address.testutil.ModuleBuilder;
 import seedu.address.testutil.ModuleUtil;
+import seedu.address.testutil.RequirementUtil;
 
 public class AddressBookParserTest {
     @Rule
@@ -141,6 +146,16 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_requirementList() throws Exception {
         assertTrue(parser.parseCommand(RequirementListCommand.COMMAND_WORD) instanceof RequirementListCommand);
+    }
+
+    @Test
+    public void parseCommand_requirementRemove() throws Exception {
+        Name name = new Name("Computing Foundation");
+        Set<Code> codeSet = new HashSet<>();
+        codeSet.add(new Code("CS1010"));
+        RequirementRemoveCommand command = (RequirementRemoveCommand)
+                parser.parseCommand(RequirementUtil.getRequirementRemoveCommand(name, codeSet));
+        assertEquals(new RequirementRemoveCommand(name, codeSet), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/RequirementRemoveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RequirementRemoveCommandParserTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.parser;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.RequirementRemoveCommand;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
+
+public class RequirementRemoveCommandParserTest {
+
+    private RequirementRemoveCommandParser parser = new RequirementRemoveCommandParser();
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid format
+        assertParseFailure(parser, " INVALID INPUT", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RequirementRemoveCommand.MESSAGE_USAGE));
+
+        // invalid name format
+        assertParseFailure(parser, " " + PREFIX_NAME + "  " + PREFIX_CODE + "CS1010 ",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid code format
+        assertParseFailure(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "1231",
+                Code.MESSAGE_CONSTRAINTS);
+
+        // invalid name and code format
+        assertParseFailure(parser, " " + PREFIX_NAME + "   " + PREFIX_CODE + "1231",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1231",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RequirementRemoveCommand.MESSAGE_USAGE));
+
+    }
+
+    @Test
+    public void parse_validArgs_returnsRequirementDeleteCommand() {
+        Name validName = new Name("Computing Foundation");
+        Set<Code> validCodeSet = new HashSet<>();
+        validCodeSet.add(new Code("CS1010"));
+
+        RequirementRemoveCommand expectedRequirementRemoveCommand =
+                new RequirementRemoveCommand(validName, validCodeSet);
+
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementRemoveCommand);
+
+        // whitespace only preamble
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementRemoveCommand);
+
+        // multiple requirement categories specified - last requirement category accepted
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Mathematics " + PREFIX_NAME
+                + "Computing Foundation " + PREFIX_CODE + "CS1010", expectedRequirementRemoveCommand);
+
+    }
+}

--- a/src/test/java/seedu/address/testutil/RequirementUtil.java
+++ b/src/test/java/seedu/address/testutil/RequirementUtil.java
@@ -1,0 +1,28 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.Set;
+
+import seedu.address.logic.commands.RequirementRemoveCommand;
+import seedu.address.model.module.Code;
+import seedu.address.model.module.Name;
+
+/**
+ * A utility class for RequirementCategory.
+ */
+public class RequirementUtil {
+
+    /**
+     * Returns an remove command string for removing the {@code code}.
+     */
+    public static String getRequirementRemoveCommand(Name requirementCategoryName, Set<Code> codeSet) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(RequirementRemoveCommand.COMMAND_WORD).append(" ");
+        sb.append(PREFIX_NAME).append(requirementCategoryName.toString()).append(" ");
+        codeSet.stream().forEach(s -> sb.append(PREFIX_CODE).append(s.value).append(" "));
+        return sb.toString();
+    }
+
+}


### PR DESCRIPTION
Resolves #92

Our application does not allow users to remove modules from requirement 
categories after adding them in via `requirement_add` command.

This makes it impossible for users to re-assign modules from one 
requirement category to another without deleting and adding the module.

Let's add `requirement_remove` command to allow users to remove modules 
from requirement categories.

* [1/3] [Logic: implement logic for 'requirement_remove' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/123/commits/0fc735ad74dff29f96b1d460d76170e86208b44e)
* [2/3] [AddressBookParser: update to take in 'requirement_remove' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/123/commits/dcb0e39a153b8999c836986dd9a4cac49e91df01)
* [3/3] [RequirementRemoveCommandTest: create test cases for implemented command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/123/commits/fe50e68280d7202f3ba70ebdcac4be57cccbfa51)