### PR TITLE
Model/util: update `SampleDataUtil#getSampleDegreePlanners()`

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -72,6 +72,18 @@ public class SampleDataUtil {
             getCodeSet()
     );
 
+    private static final DegreePlanner YEAR_1_SEMESTER_3 = new DegreePlanner(
+            new Year("1"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_1_SEMESTER_4 = new DegreePlanner(
+            new Year("1"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
     private static final DegreePlanner YEAR_2_SEMESTER_1 = new DegreePlanner(
             new Year("2"),
             new Semester("1"),
@@ -81,6 +93,18 @@ public class SampleDataUtil {
     private static final DegreePlanner YEAR_2_SEMESTER_2 = new DegreePlanner(
             new Year("2"),
             new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_3 = new DegreePlanner(
+            new Year("2"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_4 = new DegreePlanner(
+            new Year("2"),
+            new Semester("4"),
             getCodeSet()
     );
 
@@ -96,6 +120,18 @@ public class SampleDataUtil {
             getCodeSet()
     );
 
+    private static final DegreePlanner YEAR_3_SEMESTER_3 = new DegreePlanner(
+            new Year("3"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_3_SEMESTER_4 = new DegreePlanner(
+            new Year("3"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
     private static final DegreePlanner YEAR_4_SEMESTER_1 = new DegreePlanner(
             new Year("4"),
             new Semester("1"),
@@ -105,6 +141,18 @@ public class SampleDataUtil {
     private static final DegreePlanner YEAR_4_SEMESTER_2 = new DegreePlanner(
             new Year("4"),
             new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_3 = new DegreePlanner(
+            new Year("4"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_4 = new DegreePlanner(
+            new Year("4"),
+            new Semester("4"),
             getCodeSet()
     );
 
@@ -150,12 +198,20 @@ public class SampleDataUtil {
         return new DegreePlanner[] {
             YEAR_1_SEMESTER_1,
             YEAR_1_SEMESTER_2,
+            YEAR_1_SEMESTER_3,
+            YEAR_1_SEMESTER_4,
             YEAR_2_SEMESTER_1,
             YEAR_2_SEMESTER_2,
+            YEAR_2_SEMESTER_3,
+            YEAR_2_SEMESTER_4,
             YEAR_3_SEMESTER_1,
             YEAR_3_SEMESTER_2,
+            YEAR_3_SEMESTER_3,
+            YEAR_3_SEMESTER_4,
             YEAR_4_SEMESTER_1,
-            YEAR_4_SEMESTER_2
+            YEAR_4_SEMESTER_2,
+            YEAR_4_SEMESTER_3,
+            YEAR_4_SEMESTER_4
         };
     }
 


### PR DESCRIPTION
Although our application supports Semester 1, 2, 3, 4 for Year 1 through
4, the sample data does not populate Degree Planners for semesters 3 and
4 (special terms semesters 1 and 2 respectively).

To reduce confusion amongst our users, let's update
`SampleDataUtil#getSampleDegreePlanners()` to include degree planners
for all special terms semesters.