### PR TITLE
RequirementCategory: implement `requirement_list` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PlannerMoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PlannerMoveCommand.java
@@ -67,8 +67,7 @@ public class PlannerMoveCommand extends Command {
                 .orElse(null);
 
         if (sourcePlanner == null) {
-            throw new CommandException(
-                    String.format(MESSAGE_NONEXISTENT_CODE, toMove));
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, toMove));
         }
 
         if (destinationPlanner == null) {

--- a/src/main/java/seedu/address/logic/commands/RequirementListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RequirementListCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_REQUIREMENT_CATEGORIES;
+
+import java.util.stream.Collectors;
+
+import javafx.collections.ObservableList;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.module.Code;
+import seedu.address.model.requirement.RequirementCategory;
+
+/**
+ * Lists all requirement categories in the address book to the user.
+ */
+public class RequirementListCommand extends Command {
+
+    public static final String COMMAND_WORD = "requirement_list";
+
+    public static final String MESSAGE_SUCCESS = "Successfully listed all requirement categories: \n%1$s";
+
+    @Override public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.updateFilteredRequirementCategoryList(PREDICATE_SHOW_ALL_REQUIREMENT_CATEGORIES);
+        StringBuilder requirementListContent = new StringBuilder();
+
+        ObservableList<RequirementCategory> requirementCategories = model.getFilteredRequirementCategoryList();
+
+        for (RequirementCategory requirementCategory : requirementCategories) {
+            requirementListContent.append(requirementCategory.getName()).append(" ");
+
+            int currentCredits = requirementCategory.getCodeSet().stream()
+                    .map(code -> model.getModuleByCode(code).getCredits().toString())
+                    .map(Integer::parseInt).reduce(0, (totalCredits, credit) -> totalCredits + credit);
+
+            requirementListContent.append("(").append(currentCredits).append("/")
+                    .append(requirementCategory.getCredits()).append(" Modular Credits Fulfilled) \n");
+
+            if (requirementCategory.getCodeSet().isEmpty()) {
+                requirementListContent.append("No modules added!");
+            } else {
+                requirementListContent.append("Modules: ").append(requirementCategory.getCodeSet().stream()
+                        .map(Code::toString).sorted().collect(Collectors.joining(", ")));
+            }
+
+            requirementListContent.append("\n\n");
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, requirementListContent.toString()));
+
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.PlannerListAllCommand;
 import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RequirementAddCommand;
+import seedu.address.logic.commands.RequirementListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -74,6 +75,9 @@ public class AddressBookParser {
 
         case RequirementAddCommand.COMMAND_WORD:
             return new RequirementAddCommandParser().parse(arguments);
+
+        case RequirementListCommand.COMMAND_WORD:
+            return new RequirementListCommand();
 
         case HistoryCommand.COMMAND_WORD:
             return new HistoryCommand();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -103,6 +103,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns a module if there is a module with the same module code as {@code code}
+     */
+    public Module getModuleByCode(Code code) {
+        requireNonNull(code);
+        return modules.getModuleByCode(code);
+    }
+
+    /**
      * Returns true if a {@code Module} with the specified {@code Code} exists in the address book.
      */
     public boolean hasModuleCode(Code code) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,12 +84,17 @@ public interface Model {
     void setAddressBook(ReadOnlyAddressBook addressBook);
 
     /**
-     * Returns true if a module with the same identity as {@code module} exists in the address book.
+     * Returns true if a module with the same identity as {@code module} exists in the application.
      */
     boolean hasModule(Module module);
 
     /**
-     * Returns true if a {@code Module} with the specified {@code Code} exists in the address book.
+     * Returns a module object if a module with the same module code as {@code code} exists in the application.
+     */
+    Module getModuleByCode(Code code);
+
+    /**
+     * Returns true if a {@code Module} with the specified {@code Code} exists in the application.
      */
     boolean hasModuleCode(Code code);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -142,6 +142,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Module getModuleByCode(Code code) {
+        requireNonNull(code);
+        return versionedAddressBook.getModuleByCode(code);
+    }
+
+    @Override
     public boolean hasModuleCode(Code code) {
         requireNonNull(code);
         return versionedAddressBook.hasModuleCode(code);

--- a/src/main/java/seedu/address/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/address/model/module/UniqueModuleList.java
@@ -40,6 +40,17 @@ public class UniqueModuleList implements Iterable<Module> {
     }
 
     /**
+     * Returns a module object if the list contains an equivalent module code as the given argument.
+     */
+    public Module getModuleByCode(Code toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream()
+                .filter(module -> module.getCode().equals(toCheck))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
      * Adds a module to the list.
      * The module must not already exist in the list.
      */

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -161,7 +161,7 @@ public class SampleDataUtil {
             getCodeSet("CS1010", "CS1231", "CS2040C", "CS2100", "CS2102")
     );
     private static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategory(
-            new Name("Information Security Requirements"), new Credits("32"), getCodeSet()
+            new Name("Information Security Requirements"), new Credits("20"), getCodeSet()
     );
 
     private static final RequirementCategory INFORMATION_SECURITY_ELECTIVES = new RequirementCategory(

--- a/src/main/java/seedu/address/ui/DegreePlannerCard.java
+++ b/src/main/java/seedu/address/ui/DegreePlannerCard.java
@@ -50,7 +50,6 @@ public class DegreePlannerCard extends UiPart<Region> {
 
         degreePlannerListView.setItems(modules);
         degreePlannerCardPane.setOnMouseClicked(null);
-        degreePlannerCardPane.setPrefHeight(120);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -34,6 +34,7 @@ public class MainWindow extends UiPart<Stage> {
     private BrowserPanel browserPanel;
     private DegreePlannerListPanel degreePlannerListPanel;
     private ModuleListPanel moduleListPanel;
+    private RequirementCategoryListPanel requirementCategoryListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -54,6 +55,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane resultDisplayPlaceholder;
+
+    @FXML
+    private StackPane requirementCategoryListPanelPlaceholder;
 
     @FXML
     private StackPane statusbarPlaceholder;
@@ -129,6 +133,10 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
+        requirementCategoryListPanel = new RequirementCategoryListPanel(logic.getFilteredRequirementCategoryList(),
+                logic.getAddressBook().getModuleList());
+        requirementCategoryListPanelPlaceholder.getChildren().add(requirementCategoryListPanel.getRoot());
+
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath(), logic.getAddressBook());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
@@ -182,6 +190,10 @@ public class MainWindow extends UiPart<Stage> {
 
     public DegreePlannerListPanel getDegreePlannerListPanel() {
         return degreePlannerListPanel;
+    }
+
+    public RequirementCategoryListPanel getRequirementCategoryListPanel() {
+        return requirementCategoryListPanel;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ModuleCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCard.java
@@ -48,7 +48,7 @@ public class ModuleCard extends UiPart<Region> {
         this.module = module;
         id.setText(displayedIndex + ". ");
         name.setText(module.getName().fullName);
-        credits.setText(module.getCredits().value + " Module Credits");
+        credits.setText("Modular Credits: " + module.getCredits().value);
         code.setText(module.getCode().value);
 
         String corequisitesText = module.getCorequisites().stream().map(Code::toString)

--- a/src/main/java/seedu/address/ui/RequirementCategoryCard.java
+++ b/src/main/java/seedu/address/ui/RequirementCategoryCard.java
@@ -1,0 +1,95 @@
+package seedu.address.ui;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import javafx.scene.text.Text;
+import seedu.address.model.module.Credits;
+import seedu.address.model.module.Module;
+import seedu.address.model.requirement.RequirementCategory;
+
+/**
+ * An UI component that displays information of a {@code RequirementCategory}.
+ */
+public class RequirementCategoryCard extends UiPart<Region> {
+
+    private static final String FXML = "RequirementCategoryListCard.fxml";
+
+    public final RequirementCategory requirementCategory;
+
+    @FXML
+    private HBox requirementCategoryCardPane;
+
+    @FXML
+    private Label requirementCategoryName;
+
+    @FXML
+    private Label requirementCategoryCredit;
+
+    @FXML
+    private FlowPane codes;
+
+    public RequirementCategoryCard(RequirementCategory requirementCategory, ObservableList<Module> moduleList) {
+        super(FXML);
+        this.requirementCategory = requirementCategory;
+
+        requirementCategoryName.setText(requirementCategory.getName().fullName);
+
+        Stream<Module> modulesInRequirementCategory = requirementCategory.getCodeSet().stream()
+                .map(code -> moduleList.stream().filter(module -> module.getCode().equals(code)).findFirst().get());
+
+        int currentCredits = modulesInRequirementCategory.map(Module::getCredits).map(Credits::toString)
+                .map(Integer::parseInt).reduce(0, (totalCredits, credit) -> totalCredits + credit);
+
+        String creditsRequired = requirementCategory.getCredits().toString();
+
+        requirementCategoryCredit.setText("Modular Credits Fulfilled: " + currentCredits + "/" + creditsRequired);
+
+        if (currentCredits == Integer.parseInt(creditsRequired)) {
+            requirementCategoryCredit.getStyleClass().clear();
+            requirementCategoryCredit.getStyleClass().add("fulfilled");
+        }
+
+        if (currentCredits > Integer.parseInt(creditsRequired)) {
+            requirementCategoryCredit.getStyleClass().clear();
+            requirementCategoryCredit.getStyleClass().add("overAllocate");
+        }
+
+        if (requirementCategory.getCodeSet().isEmpty()) {
+            Text noCodes = new Text("No modules in this category!");
+            noCodes.getStyleClass().clear();
+            noCodes.getStyleClass().add("noModules");
+            codes.getChildren().add(noCodes);
+        } else {
+            requirementCategory.getCodeSet().stream().sorted(Comparator.comparing(code -> code.value))
+                    .forEach(code -> codes.getChildren().add(new Label(code.value)));
+        }
+
+        requirementCategoryCardPane.setOnMouseClicked(null);
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RequirementCategoryCard)) {
+            return false;
+        }
+
+        // state check
+        RequirementCategoryCard card = (RequirementCategoryCard) other;
+        return requirementCategoryName.getText().equals(card.requirementCategoryName.getText());
+    }
+}
+

--- a/src/main/java/seedu/address/ui/RequirementCategoryListPanel.java
+++ b/src/main/java/seedu/address/ui/RequirementCategoryListPanel.java
@@ -1,0 +1,52 @@
+package seedu.address.ui;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.model.module.Module;
+import seedu.address.model.requirement.RequirementCategory;
+
+/**
+ * Panel containing the list of requirement categories to be displayed.
+ * This class takes in an ObservableModule list for the sole purpose of having the ObservableModule list as a
+ * reference object.
+ * As the ObservableRequirementCategory list only contains the module code, the ObservableModule list is necessary
+ * to be able to compute the total amount of credits.
+ */
+public class RequirementCategoryListPanel extends UiPart<Region> {
+    private static final String FXML = "RequirementCategoryListPanel.fxml";
+    private ObservableList<Module> modules;
+
+
+    @FXML
+    private ListView<RequirementCategory> requirementCategories;
+
+    public RequirementCategoryListPanel(ObservableList<RequirementCategory> requirementCategoryList,
+            ObservableList<Module> moduleList) {
+        super(FXML);
+        modules = moduleList;
+        requirementCategories.setItems(requirementCategoryList);
+        requirementCategories.setCellFactory(listView -> new RequirementCategoryViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code RequirementCategory}
+     * using a {@code RequirementCategoryListCard}.
+     */
+    class RequirementCategoryViewCell extends ListCell<RequirementCategory> {
+        @Override
+        protected void updateItem(RequirementCategory requirementCategory, boolean empty) {
+            super.updateItem(requirementCategory, empty);
+
+            if (empty || requirementCategory == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new RequirementCategoryCard(requirementCategory, modules).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -107,11 +107,8 @@
     -fx-background-color: #515658;
 }
 
-.list-cell:filled:selected {
-    -fx-background-color: #424d5f;
-}
-
 .list-cell:filled:selected #cardPane {
+    -fx-background-color: #424d5f;
     -fx-border-color: #3e7b91;
     -fx-border-width: 1;
 }
@@ -334,9 +331,9 @@
 }
 
 #cardPane {
-    -fx-background-color: transparent;
-    -fx-border-width: 0;
-}
+     -fx-background-color: transparent;
+     -fx-border-width: 0;
+ }
 
 #commandTypeLabel {
     -fx-font-size: 11px;
@@ -363,7 +360,7 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#tags, #codes {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
@@ -375,4 +372,25 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+}
+
+#codes .label {
+    -fx-text-fill: white;
+    -fx-background-color: #34911c;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 15;
+}
+
+.fulfilled {
+    -fx-text-fill: green;
+}
+
+.overAllocate {
+    -fx-text-fill: red;
+}
+
+.noModules {
+    -fx-fill: white;
 }

--- a/src/main/resources/view/DegreePlannerListCard.fxml
+++ b/src/main/resources/view/DegreePlannerListCard.fxml
@@ -7,8 +7,8 @@
 <?import javafx.scene.layout.VBox?>
 
 <StackPane fx:id="degreePlannerCardPane" xmlns="http://javafx.com/javafx/8.0.172-ea"
-           xmlns:fx="http://javafx.com/fxml/1">
-    <VBox prefHeight="200" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1">
+           xmlns:fx="http://javafx.com/fxml/1" >
+    <VBox prefHeight="150" prefWidth="150" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1">
         <HBox>
             <children>
                 <Label fx:id="year"/>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -47,14 +47,22 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
-          <VBox fx:id="moduleList" minWidth="340" prefWidth="340" SplitPane.resizableWithParent="false">
+          <VBox fx:id="moduleList" maxWidth="400" minWidth="310" prefWidth="300" SplitPane.resizableWithParent="false">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
             <StackPane fx:id="moduleListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <StackPane id="plannerStackPane" fx:id="degreePlannerListPanelPlaceholder" prefWidth="340" >
+          <VBox fx:id="requirementCategories" maxWidth="400" minWidth="200" prefWidth="200">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10" />
+            </padding>
+            <StackPane fx:id="requirementCategoryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+
+          <StackPane id="plannerStackPane" fx:id="degreePlannerListPanelPlaceholder" prefWidth="120"
+                     VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="PlanWithEase" minWidth="900" minHeight="600" onCloseRequest="#handleExit">
+         title="PlanWithEase" minWidth="930" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/plan_with_ease_32.png" />
   </icons>
@@ -47,26 +47,27 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4" VBox.vgrow="ALWAYS">
-          <VBox fx:id="moduleList" maxWidth="400" minWidth="310" prefWidth="300" SplitPane.resizableWithParent="false">
+          <VBox fx:id="moduleList" minWidth="300" prefWidth="310">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
             <StackPane fx:id="moduleListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <VBox fx:id="requirementCategories" maxWidth="400" minWidth="200" prefWidth="200">
+          <VBox fx:id="requirementCategories" minWidth="300" prefWidth="310" VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
             <StackPane fx:id="requirementCategoryListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <StackPane id="plannerStackPane" fx:id="degreePlannerListPanelPlaceholder" prefWidth="120"
-                     VBox.vgrow="ALWAYS">
-            <padding>
-              <Insets top="10" right="10" bottom="10" left="10" />
-            </padding>
-          </StackPane>
+          <VBox fx:id="degreePlan" minWidth="300" prefWidth="310" VBox.vgrow="ALWAYS">
+              <StackPane id="plannerStackPane" fx:id="degreePlannerListPanelPlaceholder"  VBox.vgrow="ALWAYS">
+                <padding>
+                  <Insets top="10" right="10" bottom="10" left="10" />
+                </padding>
+              </StackPane>
+          </VBox>
         </SplitPane>
         <StackPane fx:id="browserPlaceholder" prefWidth="0" >
         </StackPane>

--- a/src/main/resources/view/RequirementCategoryListCard.fxml
+++ b/src/main/resources/view/RequirementCategoryListCard.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="requirementCategoryCardPane" fx:id="requirementCategoryCardPane" xmlns="http://javafx.com/javafx/8"
+      xmlns:fx="http://javafx.com/fxml/1">
+    <GridPane HBox.hgrow="ALWAYS">
+        <columnConstraints>
+            <ColumnConstraints hgrow="ALWAYS" minWidth="5" prefWidth="150" />
+        </columnConstraints>
+        <VBox alignment="CENTER_LEFT" minHeight="80" GridPane.columnIndex="0">
+            <padding>
+                <Insets top="5" right="5" bottom="5" left="5" />
+            </padding>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <Label fx:id="requirementCategoryName" styleClass="cell_big_label">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+            </HBox>
+            <Label fx:id="requirementCategoryCredit" styleClass="cell_small_label"
+                   text="\$requirementCategoryCredit" />
+            <FlowPane id="codes" fx:id="codes" />
+        </VBox>
+    </GridPane>
+</HBox>

--- a/src/main/resources/view/RequirementCategoryListPanel.fxml
+++ b/src/main/resources/view/RequirementCategoryListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+        <ListView fx:id="requirementCategories" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalRequirementCategoryAddressBook.json
@@ -5,7 +5,7 @@
     "codeList" : [ "CS2100" ]
   }, {
     "name" : "Information Security Requirements",
-    "credits" : "32",
+    "credits" : "20",
     "codeList" : [ ]
   }, {
     "name" : "Information Security Electives",

--- a/src/test/java/guitests/guihandles/ModuleCardHandle.java
+++ b/src/test/java/guitests/guihandles/ModuleCardHandle.java
@@ -59,8 +59,8 @@ public class ModuleCardHandle extends NodeHandle<Node> {
 
     public String getCredits() {
         String credits = creditsLabel.getText();
-        if (credits.endsWith(" Module Credits")) {
-            credits = credits.substring(0, credits.length() - " Module Credits".length());
+        if (credits.startsWith("Modular Credits: ")) {
+            credits = credits.substring("Modular Credits: ".length());
         }
         return credits;
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -168,6 +168,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public Module getModuleByCode(Code code) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasModuleCode(Code code) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/RequirementListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RequirementListCommandTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static seedu.address.testutil.TypicalModules.getTypicalModuleList;
+import static seedu.address.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.module.Code;
+import seedu.address.model.requirement.RequirementCategory;
+import seedu.address.storage.JsonSerializableAddressBook;
+
+public class RequirementListCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before public void setUp() throws IllegalValueException {
+        model = new ModelManager(new JsonSerializableAddressBook(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test public void execute_displayList() {
+        StringBuilder requirementListContent = new StringBuilder();
+
+        ObservableList<RequirementCategory> requirementCategories = model.getFilteredRequirementCategoryList();
+
+        for (RequirementCategory requirementCategory : requirementCategories) {
+            requirementListContent.append(requirementCategory.getName()).append(" ");
+
+            int currentCredits = requirementCategory.getCodeSet().stream()
+                    .map(code -> model.getModuleByCode(code).getCredits().toString())
+                    .map(Integer::parseInt).reduce(0, (totalCredits, credit) -> totalCredits + credit);
+
+            requirementListContent.append("(").append(currentCredits).append("/")
+                    .append(requirementCategory.getCredits()).append(" Modular Credits Fulfilled) \n");
+
+            if (requirementCategory.getCodeSet().isEmpty()) {
+                requirementListContent.append("No modules added!");
+            } else {
+                requirementListContent.append("Modules: ").append(requirementCategory.getCodeSet().stream()
+                        .map(Code::toString).sorted().collect(Collectors.joining(", ")));
+            }
+
+            requirementListContent.append("\n\n");
+        }
+        String expectedMessage =
+                String.format(RequirementListCommand.MESSAGE_SUCCESS, requirementListContent.toString());
+        assertCommandSuccess(new RequirementListCommand(), model, commandHistory, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -30,6 +30,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.PlannerListAllCommand;
 import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.RequirementListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -132,9 +133,14 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_plannerMove() throws Exception {
         PlannerMoveCommand command = (PlannerMoveCommand) parser.parseCommand(
-                PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
-                        + PREFIX_CODE + "CS1010");
+                PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 " + PREFIX_CODE +
+                        "CS1010");
         assertEquals(new PlannerMoveCommand(new Year("1"), new Semester("2"), new Code("CS1010")), command);
+    }
+
+    @Test
+    public void parseCommand_requirementList() throws Exception {
+        assertTrue(parser.parseCommand(RequirementListCommand.COMMAND_WORD) instanceof RequirementListCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -133,8 +133,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_plannerMove() throws Exception {
         PlannerMoveCommand command = (PlannerMoveCommand) parser.parseCommand(
-                PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 " + PREFIX_CODE +
-                        "CS1010");
+                PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 " + PREFIX_CODE
+                        + "CS1010");
         assertEquals(new PlannerMoveCommand(new Year("1"), new Semester("2"), new Code("CS1010")), command);
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -75,6 +75,12 @@ public class AddressBookTest {
     }
 
     @Test
+    public void getModuleByCode_nullCode_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        addressBook.getModuleByCode(null);
+    }
+
+    @Test
     public void hasModule_moduleNotInAddressBook_returnsFalse() {
         assertFalse(addressBook.hasModule(ALICE));
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -92,6 +92,12 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void getModuleByCode_nullCode_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.getModuleByCode(null);
+    }
+
+    @Test
     public void hasModule_moduleNotInAddressBook_returnsFalse() {
         assertFalse(modelManager.hasModule(ALICE));
     }

--- a/src/test/java/seedu/address/model/module/UniqueModuleListTest.java
+++ b/src/test/java/seedu/address/model/module/UniqueModuleListTest.java
@@ -33,6 +33,12 @@ public class UniqueModuleListTest {
     }
 
     @Test
+    public void getModuleByCode_nullCode_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueModuleList.getModuleByCode(null);
+    }
+
+    @Test
     public void contains_moduleNotInList_returnsFalse() {
         assertFalse(uniqueModuleList.contains(ALICE));
     }

--- a/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
+++ b/src/test/java/seedu/address/testutil/TypicalRequirementCategories.java
@@ -18,7 +18,7 @@ public class TypicalRequirementCategories {
                     .withCredits("36").withCodes("CS2100").build();
     public static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS =
             new RequirementCategoryBuilder().withName("Information Security Requirements")
-                    .withCredits("32").build();
+                    .withCredits("20").build();
     public static final RequirementCategory INFORMATION_SECURITY_ELECTIVES =
             new RequirementCategoryBuilder().withName("Information Security Electives")
                     .withCredits("12").build();


### PR DESCRIPTION
Resolves #132.

Our application does not allow users to view or list the requirement 
categories and their modules.

This makes it difficult for users to know what modules are in which 
requirement category, or how many modular credits they have fulfilled.

To address these issues, let's add `requirement_list` command to allows 
users to be able to view all the requirement categories, also also 
overhaul the UI to display all the requirement categories as well.

* [1/6] [Logic: implement 'requirement_list' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/ea4b496bb17c127d2777ad0493efccfae6c9185d)
* [2/6] [test: creating test cases for new command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/a3c88622c062b5ac16355d3d5ac1297ee32e050f)
* [3/6] [view: creating UI panels to display requirement categories](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/b296c335d985341b5cf5f308e8c18f9ac174b711)
* [4/6] [UI: implement the logic to display the requirement categories](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/3a3c229c368cc12283c08143b56b9bbbc7ccd6f0)
* [5/6] [Update CSS for display the requirement categories](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/57423a9f83af5ec2ad4708d63db8ee450edac1d0)
* [6/6] [Fixing files with merge conflict issues](https://github.com/CS2113-AY1819S2-T09-1/main/pull/133/commits/4f95dbad14fb2f7c5ece50e193bf99539e6ba6b8)
