### PR TITLE
 Model/util: add and use `InitialDataUtil` class

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -1,5 +1,7 @@
 package seedu.address;
 
+import static seedu.address.model.util.InitialDataUtil.getInitialAddressBook;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -15,7 +17,6 @@ import seedu.address.commons.util.ConfigUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -90,10 +91,10 @@ public class MainApp extends Application {
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
+            initialData = getInitialAddressBook();
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
+            initialData = getInitialAddressBook();
         }
 
         return new ModelManager(initialData, userPrefs);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -1,9 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.util.InitialDataUtil.getInitialAddressBook;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
@@ -18,7 +18,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        model.setAddressBook(getInitialAddressBook());
         model.commitAddressBook();
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -58,11 +58,12 @@ public class ModelManager implements Model {
         filteredRequirementCategory.addListener(this::ensureSelectedRequirementCategoryIsValid);
     }
 
-    /**
-     * ToDo: Add DegreePlannerList
-     */
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
+    }
+
+    public ModelManager(ReadOnlyAddressBook addressBook) {
+        this(addressBook, new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================

--- a/src/main/java/seedu/address/model/util/InitialDataUtil.java
+++ b/src/main/java/seedu/address/model/util/InitialDataUtil.java
@@ -1,0 +1,205 @@
+package seedu.address.model.util;
+
+import static seedu.address.model.util.SampleDataUtil.getCodeSet;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.module.Credits;
+import seedu.address.model.module.Name;
+import seedu.address.model.planner.DegreePlanner;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
+import seedu.address.model.requirement.RequirementCategory;
+
+/**
+ * Contains utility methods for populating {@code AddressBook} with sample data.
+ */
+public class InitialDataUtil {
+    private static final DegreePlanner YEAR_1_SEMESTER_1 = new DegreePlanner(
+            new Year("1"),
+            new Semester("1"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_1_SEMESTER_2 = new DegreePlanner(
+            new Year("1"),
+            new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_1_SEMESTER_3 = new DegreePlanner(
+            new Year("1"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_1_SEMESTER_4 = new DegreePlanner(
+            new Year("1"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_1 = new DegreePlanner(
+            new Year("2"),
+            new Semester("1"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_2 = new DegreePlanner(
+            new Year("2"),
+            new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_3 = new DegreePlanner(
+            new Year("2"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_2_SEMESTER_4 = new DegreePlanner(
+            new Year("2"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_3_SEMESTER_1 = new DegreePlanner(
+            new Year("3"),
+            new Semester("1"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_3_SEMESTER_2 = new DegreePlanner(
+            new Year("3"),
+            new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_3_SEMESTER_3 = new DegreePlanner(
+            new Year("3"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_3_SEMESTER_4 = new DegreePlanner(
+            new Year("3"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_1 = new DegreePlanner(
+            new Year("4"),
+            new Semester("1"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_2 = new DegreePlanner(
+            new Year("4"),
+            new Semester("2"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_3 = new DegreePlanner(
+            new Year("4"),
+            new Semester("3"),
+            getCodeSet()
+    );
+
+    private static final DegreePlanner YEAR_4_SEMESTER_4 = new DegreePlanner(
+            new Year("4"),
+            new Semester("4"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory COMPUTING_FOUNDATION = new RequirementCategory(
+            new Name("Computing Foundation"),
+            new Credits("36"),
+            getCodeSet()
+    );
+    private static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategory(
+            new Name("Information Security Requirements"),
+            new Credits("32"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory INFORMATION_SECURITY_ELECTIVES = new RequirementCategory(
+            new Name("Information Security Electives"),
+            new Credits("12"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory COMPUTING_BREADTH = new RequirementCategory(
+            new Name("Computing Breadth"),
+            new Credits("20"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory IT_PROFESSIONALISM = new RequirementCategory(
+            new Name("IT Professionalism"),
+            new Credits("8"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory MATHEMATICS = new RequirementCategory(
+            new Name("Mathematics"),
+            new Credits("12"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory GENERAL_EDUCATION = new RequirementCategory(
+            new Name("General Education"),
+            new Credits("20"),
+            getCodeSet()
+    );
+
+    private static final RequirementCategory UNRESTRICTED_ELECTIVES = new RequirementCategory(
+            new Name("Unrestricted Electives"),
+            new Credits("12"),
+            getCodeSet()
+    );
+
+    public static RequirementCategory[] getInitialRequirementCategories() {
+        return new RequirementCategory[] {
+            COMPUTING_FOUNDATION,
+            INFORMATION_SECURITY_REQUIREMENTS,
+            INFORMATION_SECURITY_ELECTIVES,
+            COMPUTING_BREADTH,
+            IT_PROFESSIONALISM,
+            MATHEMATICS,
+            GENERAL_EDUCATION,
+            UNRESTRICTED_ELECTIVES
+        };
+    }
+
+    public static DegreePlanner[] getInitialDegreePlanners() {
+        return new DegreePlanner[] {
+            YEAR_1_SEMESTER_1,
+            YEAR_1_SEMESTER_2,
+            YEAR_1_SEMESTER_3,
+            YEAR_1_SEMESTER_4,
+            YEAR_2_SEMESTER_1,
+            YEAR_2_SEMESTER_2,
+            YEAR_2_SEMESTER_3,
+            YEAR_2_SEMESTER_4,
+            YEAR_3_SEMESTER_1,
+            YEAR_3_SEMESTER_2,
+            YEAR_3_SEMESTER_3,
+            YEAR_3_SEMESTER_4,
+            YEAR_4_SEMESTER_1,
+            YEAR_4_SEMESTER_2,
+            YEAR_4_SEMESTER_3,
+            YEAR_4_SEMESTER_4
+        };
+    }
+
+    public static ReadOnlyAddressBook getInitialAddressBook() {
+        AddressBook initialAb = new AddressBook();
+        for (RequirementCategory initialRequirementCategory : getInitialRequirementCategories()) {
+            initialAb.addRequirementCategory(initialRequirementCategory);
+        }
+        for (DegreePlanner initialDegreePlanner : getInitialDegreePlanners()) {
+            initialAb.addDegreePlanner(initialDegreePlanner);
+        }
+        return initialAb;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.util.InitialDataUtil.getInitialAddressBook;
 import static seedu.address.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
 import static seedu.address.testutil.TypicalModules.getTypicalModuleList;
 import static seedu.address.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
@@ -9,7 +10,6 @@ import org.junit.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -23,6 +23,7 @@ public class ClearCommandTest {
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.setAddressBook(getInitialAddressBook());
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
@@ -37,7 +38,7 @@ public class ClearCommandTest {
                 new ModelManager(
                         new JsonSerializableAddressBook(getTypicalModuleList(), getTypicalDegreePlannerList(),
                                 getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
-        expectedModel.setAddressBook(new AddressBook());
+        expectedModel.setAddressBook(getInitialAddressBook());
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -1,6 +1,7 @@
 package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.model.util.InitialDataUtil.getInitialAddressBook;
 import static seedu.address.testutil.TypicalModules.KEYWORD_MATCHING_MEIER;
 
 import org.junit.Test;
@@ -31,9 +32,10 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
 
         /* Case: redo clearing address book -> cleared */
+        Model expectedModel = new ModelManager(getInitialAddressBook());
         command = RedoCommand.COMMAND_WORD;
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
-        assertCommandSuccess(command, expectedResultMessage, new ModelManager());
+        assertCommandSuccess(command, expectedResultMessage, expectedModel);
         assertSelectedCardUnchanged();
 
         /* Case: selects first card in module list and clears address book -> cleared and no card selected */
@@ -65,7 +67,8 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(String command) {
-        assertCommandSuccess(command, ClearCommand.MESSAGE_SUCCESS, new ModelManager());
+        Model expectedModel = new ModelManager(getInitialAddressBook());
+        assertCommandSuccess(command, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     /**


### PR DESCRIPTION
Whenever the `clear` command is executed, or when the application fails
to read the JSON save data successfully, `new AddressBook()` is passed
to `ModelManager#setAddressBook(...)` to effectively 'clear' all save
data.

However, this behaviour is undesirable, as it purges all existing
modules, requirement categories and degree planners. This causes users
to be unable to interact with requirement categories and degree planners
as they no longer exists in the application.

As such, instead of purging all the data by replacing the current
`AddressBook` to a new instance, we should replace it to a barebone copy
of an empty AddressBook that retains the respective requirement
categories and degree planner.

Let's add an `InitialDataUtil` class to provide easy access of reseting
existing data to the initial (empty) data described above, and replace 
`new AddressBook()` with `getInitialAddressBook()` whenever `clear` 
command is executed, or when the application fails to read the JSON save
data successfully. Lastly, let's update the unit tests for the `clear` 
command.

* [1/2] [Model/util: add `InitialDataUtil` class](https://github.com/CS2113-AY1819S2-T09-1/main/pull/134/commits/b8e7692c28d9828549c80ee6519ec9697ae23069)
* [2/2] [Replace `new AddressBook()` with `getInitialAddressBook()`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/134/commits/cb9bd4eed9778cc4cba0719a91ab177c06eb89e0)