### PR TITLE
Model: update `Name#VALIDATION_REGEX` and `Name#MESSAGE_CONSTRAINTS`

### DIFF
--- a/src/main/java/seedu/address/model/module/Name.java
+++ b/src/main/java/seedu/address/model/module/Name.java
@@ -10,14 +10,16 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters, punctuations and spaces, but it should not be blank";
+            "Names should only contain alphanumeric characters, punctuations (excluding \"(\", \")\", \"&\", \"|\") "
+            + "and spaces, and it should not be blank.\n"
+            + "If you are using punctuations, perhaps you may want to consider replacing \"()\" with \"[]\", \"&\" with"
+            + " \"and\", and \"|\" with \"l\" (lowercase L) instead!";
 
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Graph}][\\p{Print}]*";
-
+    public static final String VALIDATION_REGEX = "^[\\p{Graph}&&[^\\(\\)\\|\\&]][\\p{Print}&&[^\\(\\)\\|\\&]]*$";
     public final String fullName;
 
     /**


### PR DESCRIPTION
To enable `FindCommand` support for boolean expressions for more complex
filtering of results (PR #119), let's restrict `Name#VALIDATION_REGEX`
to exclude boolean operators `(`, `)`, `|`, `&` so that it is possible
to separate boolean operators from `Name` arguments.

In addition, let's update `Name#MESSAGE_CONSTRAINTS` to let users know
how to get around the restrictions by replacing:
* `()` with `[]`
* `&` with `and`
* `|` with `l` (lowercase L)