### PR TITLE
Logic/commands: implement `planner_move` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PlannerMoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PlannerMoveCommand.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Code;
+import seedu.address.model.planner.DegreePlanner;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
+
+/**
+ * Moves a module in the degree plan
+ */
+public class PlannerMoveCommand extends Command {
+
+    public static final String COMMAND_WORD = "planner_move";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Moves a module in a degree plan. "
+            + "Parameters: "
+            + PREFIX_YEAR + "YEAR "
+            + PREFIX_SEMESTER + "SEMESTER\n"
+            + PREFIX_CODE + "CODE "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_YEAR + "1 "
+            + PREFIX_SEMESTER + "2 "
+            + PREFIX_CODE + "CS1010";
+
+    public static final String MESSAGE_SUCCESS =
+            "Successfully moved %1$s to Year %2$s Semester %3$s of the degree plan!";
+    public static final String MESSAGE_NONEXISTENT_CODE =
+            "The module %1$s does not exist in the degree plan!";
+    public static final String MESSAGE_NONEXISTENT_DEGREE_PLANNER =
+            "Year %1$s Semester %2$s does not exist in the degree planner!";
+
+    private final Year destinationYear;
+    private final Semester destinationSemester;
+    private final Code toMove;
+
+    /**
+     * Creates an PlannerMoveCommand to add the specified {@code PlannerMoveCommand}
+     */
+    public PlannerMoveCommand(Year year, Semester semester, Code code) {
+        requireAllNonNull(year, semester, code);
+        this.destinationYear = year;
+        this.destinationSemester = semester;
+        this.toMove = code;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        DegreePlanner toFind = new DegreePlanner(destinationYear, destinationSemester, Collections.emptySet());
+        DegreePlanner sourcePlanner = model.getDegreePlannerByCode(toMove);
+        DegreePlanner destinationPlanner = model.getAddressBook().getDegreePlannerList().stream()
+                .filter(toFind::isSameDegreePlanner)
+                .findFirst()
+                .orElse(null);
+
+        if (sourcePlanner == null) {
+            throw new CommandException(
+                    String.format(MESSAGE_NONEXISTENT_CODE, toMove));
+        }
+
+        if (destinationPlanner == null) {
+            throw new CommandException(
+                    String.format(MESSAGE_NONEXISTENT_DEGREE_PLANNER, destinationYear, destinationSemester));
+        }
+
+        if (!sourcePlanner.isSameDegreePlanner(destinationPlanner)) {
+            Set<Code> newSourceCodes = new HashSet<>(sourcePlanner.getCodes());
+            newSourceCodes.remove(toMove);
+            Set<Code> newDestinationCodes = new HashSet<>(destinationPlanner.getCodes());
+            newDestinationCodes.add(toMove);
+
+            DegreePlanner editedSourcePlanner =
+                    new DegreePlanner(sourcePlanner.getYear(), sourcePlanner.getSemester(), newSourceCodes);
+            DegreePlanner editedDestinationPlanner =
+                    new DegreePlanner(destinationPlanner.getYear(), destinationPlanner.getSemester(),
+                            newDestinationCodes);
+
+            model.setDegreePlanner(sourcePlanner, editedSourcePlanner);
+            model.setDegreePlanner(destinationPlanner, editedDestinationPlanner);
+        }
+
+        model.commitAddressBook();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toMove, destinationYear, destinationSemester));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PlannerMoveCommand)) {
+            return false;
+        }
+
+        PlannerMoveCommand otherCommand = (PlannerMoveCommand) other;
+        return destinationYear.equals(otherCommand.destinationYear)
+                && destinationSemester.equals(otherCommand.destinationSemester)
+                && toMove.equals(otherCommand.toMove);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.PlannerListAllCommand;
+import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RequirementAddCommand;
 import seedu.address.logic.commands.SelectCommand;
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case PlannerListAllCommand.COMMAND_WORD:
             return new PlannerListAllCommand();
+
+        case PlannerMoveCommand.COMMAND_WORD:
+            return new PlannerMoveCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_CREDITS = new Prefix("credits/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/");
     public static final Prefix PREFIX_COREQUISITE = new Prefix("coreq/");
+    public static final Prefix PREFIX_YEAR = new Prefix("year/");
+    public static final Prefix PREFIX_SEMESTER = new Prefix("sem/");
 
     public static final String OPERATOR_OR = "||";
     public static final String OPERATOR_AND = "&&";

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -12,6 +12,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.module.Code;
 import seedu.address.model.module.Credits;
 import seedu.address.model.module.Name;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -79,6 +81,36 @@ public class ParserUtil {
             throw new ParseException(Code.MESSAGE_CONSTRAINTS);
         }
         return new Code(trimmedCode);
+    }
+
+    /**
+     * Parses a {@code String year} into an {@code Year}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code year} is invalid.
+     */
+    public static Year parseYear(String year) throws ParseException {
+        requireNonNull(year);
+        String trimmedYear = year.trim();
+        if (!Year.isValidYear(trimmedYear)) {
+            throw new ParseException(Year.MESSAGE_YEAR_CONSTRAINTS);
+        }
+        return new Year(trimmedYear);
+    }
+
+    /**
+     * Parses a {@code String semester} into an {@code Semester}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code year} is invalid.
+     */
+    public static Semester parseSemester(String semester) throws ParseException {
+        requireNonNull(semester);
+        String trimmedSemester = semester.trim();
+        if (!Semester.isValidSemester(trimmedSemester)) {
+            throw new ParseException(Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+        }
+        return new Semester(trimmedSemester);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/PlannerMoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PlannerMoveCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.PlannerMoveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
+
+/**
+ * Parses input arguments and creates a new PlannerMoveCommand object
+ */
+public class PlannerMoveCommandParser implements Parser<PlannerMoveCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the PlannerMoveCommand
+     * and returns an PlannerMoveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PlannerMoveCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_YEAR, PREFIX_SEMESTER, PREFIX_CODE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_YEAR, PREFIX_SEMESTER, PREFIX_CODE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerMoveCommand.MESSAGE_USAGE));
+        }
+
+        Year year = ParserUtil.parseYear(argMultimap.getValue(PREFIX_YEAR).get());
+        Semester semester = ParserUtil.parseSemester(argMultimap.getValue(PREFIX_SEMESTER).get());
+        Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
+
+        return new PlannerMoveCommand(year, semester, code);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -264,6 +264,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Return the degree planner which contains the given {@code code}, otherwise returns null.
+     */
+    public DegreePlanner getDegreePlannerByCode(Code code) {
+        requireNonNull(code);
+        return degreePlanners.getDegreePlannerByCode(code);
+    }
+
+    /**
      * Adds a degree planner to the degree planner list.
      * The degree planner must not already exist in the degree planner list.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -180,6 +180,11 @@ public interface Model {
     boolean hasDegreePlanner(DegreePlanner degreePlanner);
 
     /**
+     * Return the degree planner which contains the given {@code code}, otherwise returns null.
+     */
+    DegreePlanner getDegreePlannerByCode(Code code);
+
+    /**
      * Deletes the given degreePlanner.
      * The degreePlanner must exist in the degreePlaner list.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -302,6 +302,12 @@ public class ModelManager implements Model {
         versionedAddressBook.addDegreePlanner(degreePlanner);
     }
 
+    @Override
+    public DegreePlanner getDegreePlannerByCode(Code code) {
+        requireNonNull(code);
+        return versionedAddressBook.getDegreePlannerByCode(code);
+    }
+
     @Override public void setDegreePlanner(DegreePlanner target, DegreePlanner editedDegreePlanner) {
         requireAllNonNull(target, editedDegreePlanner);
 

--- a/src/main/java/seedu/address/model/planner/UniqueDegreePlannerList.java
+++ b/src/main/java/seedu/address/model/planner/UniqueDegreePlannerList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.module.Code;
 import seedu.address.model.planner.exceptions.DegreePlannerNotFoundException;
 import seedu.address.model.planner.exceptions.DuplicateDegreePlannerException;
 
@@ -30,11 +31,23 @@ public class UniqueDegreePlannerList implements Iterable<DegreePlanner> {
             FXCollections.unmodifiableObservableList(internalList);
 
     /**
-     * Returns true if the list contains an equivalent planner module as the given argument.
+     * Returns true if the list contains an equivalent degree planner as the given argument.
      */
     public boolean contains(DegreePlanner toCheck) {
         requireNonNull(toCheck);
         return internalList.stream().anyMatch(toCheck::isSameDegreePlanner);
+    }
+
+    /**
+     * Returns a DegreePlanner object of the degree planner in the internalList if degree planner contains the given
+     * code.
+     */
+    public DegreePlanner getDegreePlannerByCode(Code toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream()
+                .filter(degreePlanner -> degreePlanner.getCodes().contains(toCheck))
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/src/test/data/JsonSerializableAddressBookTest/typicalDegreePlannerAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalDegreePlannerAddressBook.json
@@ -23,13 +23,5 @@
     "year" : "3",
     "semester" : "2",
     "codes" : [ ]
-  }, {
-    "year" : "4",
-    "semester" : "1",
-    "codes" : [ ]
-  }, {
-    "year" : "4",
-    "semester" : "2",
-    "codes" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -243,6 +243,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public DegreePlanner getDegreePlannerByCode(Code toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deleteDegreePlanner(DegreePlanner degreePlanner) {
             //ToDo: implement AssertionError
         }

--- a/src/test/java/seedu/address/logic/commands/PlannerMoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/PlannerMoveCommandTest.java
@@ -1,0 +1,190 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static seedu.address.testutil.TypicalModules.getTypicalModuleList;
+import static seedu.address.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.module.Code;
+import seedu.address.model.planner.DegreePlanner;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
+import seedu.address.storage.JsonSerializableAddressBook;
+
+public class PlannerMoveCommandTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+    private Model model;
+
+    @Before
+    public void setUp() throws IllegalValueException {
+        model = new ModelManager(
+                new JsonSerializableAddressBook(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                        getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_nonExistentCode_throwsCommandException() {
+        Code nonExistentCode = new Code("CS9999");
+        Year validYear = new Year("1");
+        Semester validSemester = new Semester("2");
+        assertCommandFailure(new PlannerMoveCommand(validYear, validSemester, nonExistentCode), model,
+                commandHistory, String.format(PlannerMoveCommand.MESSAGE_NONEXISTENT_CODE, nonExistentCode));
+    }
+
+    @Test
+    public void execute_nonExistentYear_throwsCommandException() {
+        Code validCodeToMove = new Code("CS1010");
+        Year nonExistentYear = new Year("4");
+        Semester validSemester = new Semester("1");
+        assertCommandFailure(new PlannerMoveCommand(nonExistentYear, validSemester, validCodeToMove), model,
+                commandHistory,
+                String.format(PlannerMoveCommand.MESSAGE_NONEXISTENT_DEGREE_PLANNER, nonExistentYear, validSemester));
+    }
+
+    @Test
+    public void execute_nonExistentSemester_throwsCommandException() {
+        Code validCodeToMove = new Code("CS1010");
+        Year validYear = new Year("1");
+        Semester nonExistentSemester = new Semester("4");
+        assertCommandFailure(new PlannerMoveCommand(validYear, nonExistentSemester, validCodeToMove), model,
+                commandHistory,
+                String.format(PlannerMoveCommand.MESSAGE_NONEXISTENT_DEGREE_PLANNER, validYear, nonExistentSemester));
+    }
+
+    @Test
+    public void execute_validPlannerUnfilteredList_success() throws Exception {
+        Code validCodeToMove = new Code("CS1010");
+        Year validYear = new Year("1");
+        Semester validSemester = new Semester("2");
+        DegreePlanner toFind = new DegreePlanner(validYear, validSemester, Collections.emptySet());
+        DegreePlanner sourcePlannerToEdit = model.getDegreePlannerByCode(validCodeToMove);
+        DegreePlanner destinationPlannerToEdit = model.getAddressBook().getDegreePlannerList().stream()
+                .filter(toFind::isSameDegreePlanner)
+                .findFirst()
+                .orElse(null);
+
+        PlannerMoveCommand plannerMoveCommand =
+                new PlannerMoveCommand(validYear, validSemester, validCodeToMove);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        String expectedMessage =
+                String.format(PlannerMoveCommand.MESSAGE_SUCCESS, validCodeToMove, validYear, validSemester);
+
+        Set<Code> newSourceCodes = new HashSet<>(sourcePlannerToEdit.getCodes());
+        newSourceCodes.remove(validCodeToMove);
+        Set<Code> newDestinationCodes = new HashSet<>(destinationPlannerToEdit.getCodes());
+        newDestinationCodes.add(validCodeToMove);
+
+        DegreePlanner editedSourcePlanner =
+                new DegreePlanner(sourcePlannerToEdit.getYear(), sourcePlannerToEdit.getSemester(), newSourceCodes);
+        DegreePlanner editedDestinationPlanner =
+                new DegreePlanner(destinationPlannerToEdit.getYear(), destinationPlannerToEdit.getSemester(),
+                        newDestinationCodes);
+        expectedModel.setDegreePlanner(sourcePlannerToEdit, editedSourcePlanner);
+        expectedModel.setDegreePlanner(destinationPlannerToEdit, editedDestinationPlanner);
+        expectedModel.commitAddressBook();
+
+        // plannerMove -> module moved
+        assertCommandSuccess(plannerMoveCommand, model, commandHistory, expectedMessage, expectedModel);
+
+        // undo -> reverts addressbook back to previous state and filtered module list to show all modules
+        expectedModel.undoAddressBook();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // redo -> same first module deleted again
+        expectedModel.redoAddressBook();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_moveToSamePlannerUnfilteredList_success() {
+        Code validCodeToMove = new Code("CS1010");
+        Year validYear = new Year("1");
+        Semester validSemester = new Semester("1");
+
+        PlannerMoveCommand plannerMoveCommand =
+                new PlannerMoveCommand(validYear, validSemester, validCodeToMove);
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.commitAddressBook();
+
+        String expectedMessage =
+                String.format(PlannerMoveCommand.MESSAGE_SUCCESS, validCodeToMove, validYear, validSemester);
+
+        assertCommandSuccess(plannerMoveCommand, model, commandHistory, expectedMessage, expectedModel);
+
+        // undo -> reverts addressbook back to previous state and filtered module list to show all modules
+        expectedModel.undoAddressBook();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // redo -> same first module deleted again
+        expectedModel.redoAddressBook();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void executeUndoRedo_invalidPlannerUnfilteredList_success() {
+        Code invalidCodeToMove = new Code("CS9999");
+        Year validYear = new Year("1");
+        Semester validSemester = new Semester("2");
+        PlannerMoveCommand plannerMoveCommand =
+                new PlannerMoveCommand(validYear, validSemester, invalidCodeToMove);
+
+        // execution failed -> address book state not added into model
+        assertCommandFailure(plannerMoveCommand, model, commandHistory,
+                String.format(PlannerMoveCommand.MESSAGE_NONEXISTENT_CODE, invalidCodeToMove));
+
+        // single address book state in model -> undoCommand and redoCommand fail
+        assertCommandFailure(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_FAILURE);
+        assertCommandFailure(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_FAILURE);
+    }
+
+    @Test
+    public void equals() {
+        Code firstCodeToMove = new Code("CS1111");
+        Code secondCodeToMove = new Code("CS2222");
+        Year firstValidYear = new Year("1");
+        Year secondValidYear = new Year("1");
+        Semester firstValidSemester = new Semester("1");
+        Semester secondValidSemester = new Semester("2");
+
+        PlannerMoveCommand plannerMoveFirstCommand =
+                new PlannerMoveCommand(firstValidYear, firstValidSemester, firstCodeToMove);
+        PlannerMoveCommand plannerMoveSecondCommand =
+                new PlannerMoveCommand(secondValidYear, secondValidSemester, secondCodeToMove);
+
+        // same object -> returns true
+        assertTrue(plannerMoveFirstCommand.equals(plannerMoveFirstCommand));
+
+        // same values -> returns true
+        PlannerMoveCommand plannerMoveFirstCommandCopy =
+                new PlannerMoveCommand(firstValidYear, firstValidSemester, firstCodeToMove);
+        assertTrue(plannerMoveFirstCommand.equals(plannerMoveFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(plannerMoveFirstCommand.equals(1));
+
+        // different module -> returns false
+        assertFalse(plannerMoveFirstCommand.equals(plannerMoveSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,7 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import java.util.Arrays;
@@ -25,12 +28,16 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.PlannerListAllCommand;
+import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.NameContainsKeywordsPredicate;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
 import seedu.address.testutil.EditModuleDescriptorBuilder;
 import seedu.address.testutil.ModuleBuilder;
 import seedu.address.testutil.ModuleUtil;
@@ -120,6 +127,14 @@ public class AddressBookParserTest {
     public void parseCommand_plannerListAll() throws Exception {
         assertTrue(parser.parseCommand(PlannerListAllCommand.COMMAND_WORD) instanceof PlannerListAllCommand);
         assertTrue(parser.parseCommand(PlannerListAllCommand.COMMAND_WORD + " 3") instanceof PlannerListAllCommand);
+    }
+
+    @Test
+    public void parseCommand_plannerMove() throws Exception {
+        PlannerMoveCommand command = (PlannerMoveCommand) parser.parseCommand(
+                PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                        + PREFIX_CODE + "CS1010");
+        assertEquals(new PlannerMoveCommand(new Year("1"), new Semester("2"), new Code("CS1010")), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/PlannerMoveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PlannerMoveCommandParserTest.java
@@ -1,0 +1,108 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.PlannerMoveCommand;
+import seedu.address.model.module.Code;
+import seedu.address.model.planner.Semester;
+import seedu.address.model.planner.Year;
+
+public class PlannerMoveCommandParserTest {
+    private PlannerMoveCommandParser parser = new PlannerMoveCommandParser();
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid code
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "1 "
+                + PREFIX_CODE + "INVALID", Code.MESSAGE_CONSTRAINTS);
+
+        // invalid year
+        assertParseFailure(parser, " " + PREFIX_YEAR + "999 " + PREFIX_SEMESTER + "1 "
+                + PREFIX_CODE + "CS1010", Year.MESSAGE_YEAR_CONSTRAINTS);
+
+        // invalid semester
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "999 "
+                + PREFIX_CODE + "CS1010", Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "999 "
+                + PREFIX_CODE + "INVALID", Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "1 " + PREFIX_CODE + "CS1010 ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerMoveCommand.MESSAGE_USAGE));
+
+    }
+
+    @Test
+    public void parse_validArgs_returnsPlannerMoveCommand() {
+        Code ValidCodeToMove = new Code("CS1010");
+        Year validYear = new Year("1");
+        Semester validSemester = new Semester("2");
+
+        PlannerMoveCommand expectedPlannerMoveCommand =
+                new PlannerMoveCommand(validYear, validSemester, ValidCodeToMove);
+
+        assertParseSuccess(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + "CS1010", expectedPlannerMoveCommand);
+
+        // whitespace only preamble
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                        + PREFIX_CODE + "CS1010", expectedPlannerMoveCommand);
+
+        // multiple codes - last code accepted
+        assertParseSuccess(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + "CS1011 " + PREFIX_CODE + "CS1010 ", expectedPlannerMoveCommand);
+
+        // multiple years - last year accepted
+        assertParseSuccess(parser, " " + PREFIX_YEAR + "2 " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + "CS1010 ", expectedPlannerMoveCommand);
+
+        // multiple semesters - last semester accepted
+        assertParseSuccess(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "1 " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + "CS1010 ", expectedPlannerMoveCommand);
+    }
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no year specified
+        assertParseFailure(parser, " " + PREFIX_YEAR + " " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + "CS1010", Year.MESSAGE_YEAR_CONSTRAINTS);
+
+        // no semester specified
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + " "
+                + PREFIX_CODE + "CS1010", Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+
+        // no code specified
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 "
+                + PREFIX_CODE + " ", Code.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerMoveCommand.MESSAGE_USAGE);
+
+        // missing year prefix
+        assertParseFailure(parser, " " + "1 " + PREFIX_SEMESTER + "2 " + PREFIX_CODE + "CS1010", expectedMessage);
+
+        // missing semester prefix
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + "2 " + PREFIX_CODE + "CS1010", expectedMessage);
+
+        // missing code prefix
+        assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 " + "CS1010", expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, "1 " + "2 " + "CS1010", expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalDegreePlanners.java
+++ b/src/test/java/seedu/address/testutil/TypicalDegreePlanners.java
@@ -26,10 +26,6 @@ public class TypicalDegreePlanners {
             new DegreePlannerBuilder().withYear("3").withSemester("1").build();
     private static final DegreePlanner YEAR_3_SEMESTER_2 =
             new DegreePlannerBuilder().withYear("3").withSemester("2").build();
-    private static final DegreePlanner YEAR_4_SEMESTER_1 =
-            new DegreePlannerBuilder().withYear("4").withSemester("1").build();
-    private static final DegreePlanner YEAR_4_SEMESTER_2 =
-            new DegreePlannerBuilder().withYear("4").withSemester("2").build();
 
     /**
      * Returns an {@code AddressBook} with all the typical degree planners.
@@ -44,6 +40,6 @@ public class TypicalDegreePlanners {
 
     public static List<DegreePlanner> getTypicalDegreePlanners() {
         return new ArrayList<>(Arrays.asList(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_2, YEAR_2_SEMESTER_1, YEAR_2_SEMESTER_2,
-                YEAR_3_SEMESTER_1, YEAR_3_SEMESTER_2, YEAR_4_SEMESTER_1, YEAR_4_SEMESTER_2));
+                YEAR_3_SEMESTER_1, YEAR_3_SEMESTER_2));
     }
 }


### PR DESCRIPTION
Resolves #93 

The current implementation does not allow users to be able to move a 
module that has been added to a degree plan from one to another degree 
plan.

Let's implement a `planner_move` command to allow users to move a module
in a degree plan.

Note: This command does not yet support moving co-requisites 
automatically.

Followings are the changes made in the process of implementing `planner_move`:
* [1/3] [Logic: update to handle 'planner_move' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/136/commits/817f453f345daec798a55e7b79d431a642c2f8ba)
* [2/3] [Model: update to handle 'planner_move' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/136/commits/39cd71cac0bfd52996e965785c4cec68e6b1596d)
* [3/3] [Test: update to include test for 'planner_move' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/136/commits/297fa2eeddf6231403adb597ad11b72e427e9beb)
