### PR TITLE
test/CommandParserTestUtil: address `javac` linter warnings

### DIFF
--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -14,7 +14,7 @@ public class CommandParserTestUtil {
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
      * equals to {@code expectedCommand}.
      */
-    public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
+    public static void assertParseSuccess(Parser<?> parser, String userInput, Command expectedCommand) {
         try {
             Command command = parser.parse(userInput);
             assertEquals(expectedCommand, command);
@@ -27,7 +27,7 @@ public class CommandParserTestUtil {
      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
      * equals to {@code expectedMessage}.
      */
-    public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
+    public static void assertParseFailure(Parser<?> parser, String userInput, String expectedMessage) {
         try {
             parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");


### PR DESCRIPTION
`CommandParserTestUtil#assertParseSuccess(...)` and
`CommandParserTestUtil#assertParseFailure(...)` expects an instance of
the raw `Parser` object instead of the required `Parser<?>`.

As a result, the `javac` linter is unable to determine the generic class
at compile time, and thus it reported warnings of unchecked methods.

This may appear to be harmless, but it may cause runtime bugs in the
future.

Let's address the `javac` linter warnings by fixing the methods'
argument types in `CommandParserTestUtil` class.