### PR TITLE
Logic: update `EditCommand` success and error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.isAnyNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
@@ -16,7 +18,6 @@ import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -27,31 +28,46 @@ import seedu.address.model.module.Name;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing module in the address book.
+ * Edits the details of an existing {@link Module} in the {@link seedu.address.model.AddressBook#modules module list}.
  */
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the module identified "
-            + "by the index number used in the displayed module list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD
+            + " INDEX "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_CODE + "CODE] "
             + "[" + PREFIX_CREDITS + "CREDITS] "
             + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_COREQUISITE + "COREQUISITE]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_CREDITS + "8 ";
+            + "Example: To edit the number of credits assigned to the first module in the displayed module list below"
+            + ", you can enter: " + COMMAND_WORD + " 1 " + PREFIX_CREDITS + "8 ";
 
-    public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the address book.";
-    public static final String MESSAGE_INVALID_COREQUISITE =
-            "The module code (%1$s) cannot be a co-requisite of itself!";
+    // General command help details
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the existing details (e.g. name, code, credits) of a module in the displayed module list.\n"
+            + "To choose which module you want to edit, please include the index number "
+            + "(beside the module code) in the displayed module list."
+            + '\n' + FORMAT_AND_EXAMPLES;
+
+    // Command success message
+    public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Successfully edited the module (%1$s) to:\n%2$s";
+
+    // Command failure messages
+    public static final String MESSAGE_DUPLICATE_MODULE =
+            "You cannot edit module (%1$s) to have the module code %2$s.\n"
+            + "Module (%2$s) already exists in the module list!";
+    public static final String MESSAGE_INVALID_COREQUISITE = "A module cannot be a co-requisite of itself!\n"
+            + "Perhaps you might have entered the new co-requisites module(s) incorrectly?";
+    public static final String MESSAGE_NOT_EDITED = "You didn't specify what module details you want to edit.\n"
+            + "Perhaps you would like to see the command format and example again?\n"
+            + FORMAT_AND_EXAMPLES;
     public static final String MESSAGE_NON_EXISTENT_COREQUISITE =
-            "The corequisite module code (%1$s) does not exists in the module list";
+            "You cannot edit the module (%1$s) to have a co-requisite module (%2$s) "
+            + "that does not exists in the module list!\n"
+            + "[Tip] You can add the module (%1$s), and specify the module (%2$s) as a co-requisite instead!\n";
 
     private final Index index;
     private final EditModuleDescriptor editModuleDescriptor;
@@ -61,16 +77,16 @@ public class EditCommand extends Command {
      * @param editModuleDescriptor details to edit the module with
      */
     public EditCommand(Index index, EditModuleDescriptor editModuleDescriptor) {
-        requireNonNull(index);
-        requireNonNull(editModuleDescriptor);
+        requireAllNonNull(index, editModuleDescriptor);
 
         this.index = index;
-        this.editModuleDescriptor = new EditModuleDescriptor(editModuleDescriptor);
+        this.editModuleDescriptor = editModuleDescriptor;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+
         List<Module> lastShownList = model.getFilteredModuleList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -81,20 +97,30 @@ public class EditCommand extends Command {
         Module editedModule = createEditedModule(moduleToEdit, editModuleDescriptor);
 
         if (!moduleToEdit.isSameModule(editedModule) && model.hasModule(editedModule)) {
-            throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+            throw new CommandException(
+                    String.format(MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(), editedModule.getCode())
+            );
         }
         for (Code corequisite : editedModule.getCorequisites()) {
             if (moduleToEdit.getCode().equals(corequisite)) {
-                throw new CommandException(String.format(MESSAGE_INVALID_COREQUISITE, corequisite));
+                throw new CommandException(MESSAGE_INVALID_COREQUISITE);
             } else if (!model.hasModuleCode(corequisite)) {
-                throw new CommandException(String.format(MESSAGE_NON_EXISTENT_COREQUISITE, corequisite));
+                throw new CommandException(
+                        String.format(MESSAGE_NON_EXISTENT_COREQUISITE, moduleToEdit.getCode(), corequisite)
+                );
             }
         }
 
         model.editModule(moduleToEdit, editedModule);
         model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
         model.commitAddressBook();
-        return new CommandResult(String.format(MESSAGE_EDIT_MODULE_SUCCESS, editedModule));
+
+        Module editedModuleInModuleList = model.getFilteredModuleList().stream()
+                .filter(module -> editedModule.getCode().equals(module.getCode())).findFirst().get();
+
+        return new CommandResult(
+                String.format(MESSAGE_EDIT_MODULE_SUCCESS, moduleToEdit.getCode(), editedModuleInModuleList)
+        );
     }
 
     /**
@@ -103,6 +129,7 @@ public class EditCommand extends Command {
      */
     private static Module createEditedModule(Module moduleToEdit, EditModuleDescriptor editModuleDescriptor) {
         assert moduleToEdit != null;
+        assert editModuleDescriptor != null;
 
         Name updatedName = editModuleDescriptor.getName().orElse(moduleToEdit.getName());
         Credits updatedCredits = editModuleDescriptor.getCredits().orElse(moduleToEdit.getCredits());
@@ -132,8 +159,8 @@ public class EditCommand extends Command {
     }
 
     /**
-     * Stores the details to edit the module with. Each non-empty field value will replace the
-     * corresponding field value of the module.
+     * Stores the details to edit the module with.<br>
+     * Each non-empty field value will replace the corresponding field value of the module.
      */
     public static class EditModuleDescriptor {
         private Name name;
@@ -145,10 +172,13 @@ public class EditCommand extends Command {
         public EditModuleDescriptor() {}
 
         /**
-         * Copy constructor.
-         * A defensive copy of {@code tags} is used internally.
+         * Copy constructor.<br>
+         * Defensive copies of {@code tags} and {@code corequisites} are used internally to prevent accidental
+         * modifications.
          */
         public EditModuleDescriptor(EditModuleDescriptor toCopy) {
+            requireNonNull(toCopy);
+
             setName(toCopy.name);
             setCredits(toCopy.credits);
             setCode(toCopy.code);
@@ -160,7 +190,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, credits, code, tags, corequisites);
+            return isAnyNonNull(name, credits, code, tags, corequisites);
         }
 
         public void setName(Name name) {
@@ -188,37 +218,47 @@ public class EditCommand extends Command {
         }
 
         /**
-         * Sets {@code tags} to this object's {@code tags}.
+         * Sets {@code tags} to this object's {@link #tags}.<br>
          * A defensive copy of {@code tags} is used internally.
          */
         public void setTags(Set<Tag> tags) {
-            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+            this.tags = (tags != null)
+                    ? new HashSet<>(tags)
+                    : null;
         }
 
         /**
-         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * Returns an unmodifiable {@link Tag} set, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
-         * Returns {@code Optional#empty()} if {@code tags} is null.
+         * <br><br>
+         * Returns {@code Optional#empty()} if {@link #tags} is null.
          */
         public Optional<Set<Tag>> getTags() {
-            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+            return tags != null
+                    ? Optional.of(Collections.unmodifiableSet(tags))
+                    : Optional.empty();
         }
 
         /**
-         * Sets {@code corequisites} to this object's {@code corequisites}.
+         * Sets {@code corequisites} to this object's {@link #corequisites}.
          * A defensive copy of {@code corequisites} is used internally.
          */
         public void setCorequisites(Set<Code> corequisites) {
-            this.corequisites = (corequisites != null) ? new HashSet<>(corequisites) : null;
+            this.corequisites = (corequisites != null)
+                    ? new HashSet<>(corequisites)
+                    : null;
         }
 
         /**
-         * Returns an unmodifiable {@code Code} set, which throws {@code UnsupportedOperationException}
+         * Returns an unmodifiable {@link Code} set, which throws {@code UnsupportedOperationException}
          * if modification is attempted.
+         * <br><br>
          * Returns {@code Optional#empty()} if {@code corequisites} is null.
          */
         public Optional<Set<Code>> getCorequisites() {
-            return (corequisites != null) ? Optional.of(Collections.unmodifiableSet(corequisites)) : Optional.empty();
+            return corequisites != null
+                    ? Optional.of(Collections.unmodifiableSet(corequisites))
+                    : Optional.empty();
         }
 
         @Override
@@ -235,7 +275,6 @@ public class EditCommand extends Command {
 
             // state check
             EditModuleDescriptor e = (EditModuleDescriptor) other;
-
             return getName().equals(e.getName())
                     && getCredits().equals(e.getCredits())
                     && getCode().equals(e.getCode())

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -32,9 +32,14 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG,
-                        PREFIX_COREQUISITE);
+
+        if (args.isEmpty()) {
+            throw new ParseException(EditCommand.MESSAGE_USAGE);
+        }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG, PREFIX_COREQUISITE
+        );
 
         Index index;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -47,11 +47,14 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Module moduleInFilteredList = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
         Module editedModule = new ModuleBuilder().build();
         EditCommand.EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder(editedModule).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, moduleInFilteredList.getCode(), editedModule
+        );
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
@@ -74,7 +77,9 @@ public class EditCommandTest {
                 .withCredits(VALID_CREDITS_BOB).withTags(VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastModule, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, lastModule.getCode(), editedModule
+        );
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.editModule(lastModule, editedModule);
@@ -85,10 +90,13 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
+        Module firstModule = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE, new EditCommand.EditModuleDescriptor());
         Module editedModule = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, firstModule.getCode(), editedModule
+        );
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.commitAddressBook();
@@ -105,7 +113,9 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE,
                 new EditModuleDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule);
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, moduleInFilteredList.getCode(), editedModule
+        );
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.editModule(model.getFilteredModuleList().get(0), editedModule);
@@ -117,10 +127,15 @@ public class EditCommandTest {
     @Test
     public void execute_duplicateModuleUnfilteredList_failure() {
         Module firstModule = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
+        Module secondModule = model.getFilteredModuleList().get(INDEX_SECOND_MODULE.getZeroBased());
         EditModuleDescriptor descriptor = new EditModuleDescriptorBuilder(firstModule).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_MODULE, descriptor);
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_DUPLICATE_MODULE, secondModule.getCode(), firstModule.getCode()
+        );
+
+        assertCommandFailure(editCommand, model, commandHistory, expectedMessage);
     }
 
     @Test
@@ -128,11 +143,14 @@ public class EditCommandTest {
         showModuleAtIndex(model, INDEX_FIRST_MODULE);
 
         // edit module in filtered list into a duplicate in address book
-        Module moduleInList = model.getAddressBook().getModuleList().get(INDEX_SECOND_MODULE.getZeroBased());
+        Module moduleToEdit = model.getAddressBook().getModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
+        Module moduleToClone = model.getAddressBook().getModuleList().get(INDEX_SECOND_MODULE.getZeroBased());
         EditCommand editCommand = new EditCommand(INDEX_FIRST_MODULE,
-                new EditModuleDescriptorBuilder(moduleInList).build());
+                new EditModuleDescriptorBuilder(moduleToClone).build());
+        String expectedMessage = String.format(EditCommand.MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(),
+                moduleToClone.getCode());
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        assertCommandFailure(editCommand, model, commandHistory, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -55,7 +55,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", EditCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -15,6 +15,7 @@ import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CODE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -80,18 +81,26 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertNotEquals(getModel().getFilteredModuleList().get(index.getZeroBased()), BOB);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + CREDITS_DESC_BOB
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        Module moduleToEdit = getModel().getFilteredModuleList().get(index.getZeroBased());
+        expectedResultMessage = String.format(
+                EditCommand.MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(), VALID_CODE_BOB
+        );
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: edit a module with new values same as another module's values but with different credits -> rejected */
         index = INDEX_SECOND_MODULE;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + CREDITS_DESC_AMY
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        moduleToEdit = getModel().getFilteredModuleList().get(index.getZeroBased());
+        expectedResultMessage = String.format(
+                EditCommand.MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(), VALID_CODE_BOB
+        );
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_MODULE;
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + PREFIX_TAG.getPrefix();
-        Module moduleToEdit = getModel().getFilteredModuleList().get(index.getZeroBased());
+        moduleToEdit = getModel().getFilteredModuleList().get(index.getZeroBased());
         editedModule = new ModuleBuilder(moduleToEdit).withTags().build();
         assertCommandSuccess(command, index, editedModule);
 
@@ -174,12 +183,19 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertFalse(getModel().getFilteredModuleList().get(index.getZeroBased()).equals(BOB));
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + CREDITS_DESC_BOB
                 + CODE_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        moduleToEdit = getModel().getFilteredModuleList().get(index.getZeroBased());
+        expectedResultMessage = String.format(
+                EditCommand.MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(), VALID_CODE_BOB
+        );
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: edit a module with new values same as another module's values but with different tags -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_BOB + CREDITS_DESC_BOB
                 + CODE_DESC_BOB + TAG_DESC_HUSBAND;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_MODULE);
+        expectedResultMessage = String.format(
+                EditCommand.MESSAGE_DUPLICATE_MODULE, moduleToEdit.getCode(), VALID_CODE_BOB
+        );
+        assertCommandFailure(command, expectedResultMessage);
     }
 
     /**
@@ -203,11 +219,14 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
     private void assertCommandSuccess(String command, Index toEdit, Module editedModule,
             Index expectedSelectedCardIndex) {
         Model expectedModel = getModel();
+        Module originalModule = expectedModel.getFilteredModuleList().get(toEdit.getZeroBased());
+        String expectedMessage = String.format(
+                EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, originalModule.getCode(), editedModule
+        );
         expectedModel.editModule(expectedModel.getFilteredModuleList().get(toEdit.getZeroBased()), editedModule);
         expectedModel.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
 
-        assertCommandSuccess(command, expectedModel,
-                String.format(EditCommand.MESSAGE_EDIT_MODULE_SUCCESS, editedModule), expectedSelectedCardIndex);
+        assertCommandSuccess(command, expectedModel, expectedMessage, expectedSelectedCardIndex);
     }
 
     /**


### PR DESCRIPTION
The error messages of `EditCommand` are very vague, and do not provide
much information to help users fix incorrect command usage.

Additionally, when editing a module, a user may not remember what module
was modified.

Furthermore, when users simply executes the `edit` command without any
parameters specified, they are greeted with "Invalid command format!".
This may cause users to feel more confused.

Let's update the success and error messages of `EditCommand` to address
the above problems by making the messages easy to understand and provide
relevant information to help them fix incorrect command usage. Also,
let's simply print `EditCommand#MESSAGE_USAGE` instead of
`CliSyntax#MESSAGE_INVALID_COMMAND_FORMAT`.