### PR TITLE
Logic: update `AddCommand` success and error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -14,32 +14,45 @@ import seedu.address.model.module.Code;
 import seedu.address.model.module.Module;
 
 /**
- * Adds a module to the address book.
+ * Adds a {@link Module} to the {@link seedu.address.model.AddressBook#modules module list}.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to module list. "
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD + ' '
             + PREFIX_CODE + "CODE "
+            + PREFIX_NAME + "NAME "
             + PREFIX_CREDITS + "CREDITS "
-            + "[" + PREFIX_TAG + "TAG]... "
-            + "[" + PREFIX_COREQUISITE + "COREQUISITE]...\n"
+            + "[" + PREFIX_COREQUISITE + "COREQUISITE]... "
+            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "Data Structures and Algorithms "
-            + PREFIX_CODE + "CS2040C "
+            + PREFIX_CODE + "CS2113T "
+            + PREFIX_NAME + "Software Engineering and Object-Oriented Programming "
             + PREFIX_CREDITS + "4 "
-            + PREFIX_TAG + "linkedlist "
-            + PREFIX_TAG + "stack "
-            + PREFIX_TAG + "queue "
-            + PREFIX_COREQUISITE + "CS1010";
+            + PREFIX_COREQUISITE + "CS2101 "
+            + PREFIX_TAG + "OOP "
+            + PREFIX_TAG + "RCS "
+            + PREFIX_TAG + "UML";
 
-    public static final String MESSAGE_SUCCESS = "New module added: %1$s";
-    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the module list";
+    // General command help details
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a new module to the module list.\n"
+            + FORMAT_AND_EXAMPLES;
+
+    // Command success message
+    public static final String MESSAGE_SUCCESS = "Successfully added a new module:\n%1$s";
+
+    // Command failure messages
+    public static final String MESSAGE_DUPLICATE_MODULE =
+            "You cannot add a new module (%1$s), as the module code %1$s already exists in the module list!";
+
     public static final String MESSAGE_NON_EXISTENT_COREQUISITE =
-            "The corequisite module code (%1$s) does not exists in the module list";
+            "You cannot add a new module (%1$s) that has a co-requisite module (%2$s) "
+            + "which does not exists in the module list!\n"
+            + "[Tip] You can try adding the module (%1$s) without specifying the co-requisite module (%2$s) first.\n"
+            + "Afterwards, add the module (%2$s) and specify the module (%1$s) as a co-requisite.\n"
+            + "This will make both modules (%1$s & %2$s) co-requisites!";
 
     private final Module toAdd;
 
@@ -56,12 +69,14 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasModule(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_MODULE);
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, toAdd.getCode()));
         }
 
         for (Code corequisite : toAdd.getCorequisites()) {
             if (!model.hasModuleCode(corequisite)) {
-                throw new CommandException(String.format(MESSAGE_NON_EXISTENT_COREQUISITE, corequisite));
+                throw new CommandException(String.format(
+                        MESSAGE_NON_EXISTENT_COREQUISITE, toAdd.getCode(), corequisite)
+                );
             }
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
@@ -24,28 +25,33 @@ import seedu.address.model.tag.Tag;
 public class AddCommandParser implements Parser<AddCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@link AddCommand}
+     * and returns an {@link AddCommand} object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG,
-                        PREFIX_COREQUISITE);
+        requireNonNull(args);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (args.isEmpty()) {
+            throw new ParseException(AddCommand.MESSAGE_USAGE);
+        }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG, PREFIX_COREQUISITE
+        );
+
+        boolean isAnyRequiredPrefixAbsent = !arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
+        if (isAnyRequiredPrefixAbsent || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
+        Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Credits credits = ParserUtil.parseCredits(argMultimap.getValue(PREFIX_CREDITS).get());
-        Code code = ParserUtil.parseCode(argMultimap.getValue(PREFIX_CODE).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Set<Code> corequisiteList = ParserUtil.parseCorequisites(argMultimap.getAllValues(PREFIX_COREQUISITE));
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Module module = new Module(name, credits, code, tagList, corequisiteList);
-
         return new AddCommand(module);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -50,7 +50,8 @@ public class AddCommandIntegrationTest {
     public void execute_duplicateModule_throwsCommandException() {
         Module moduleInList = model.getAddressBook().getModuleList().get(0);
         assertCommandFailure(new AddCommand(moduleInList), model, commandHistory,
-                AddCommand.MESSAGE_DUPLICATE_MODULE);
+                String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, moduleInList.getCode())
+        );
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -64,7 +64,7 @@ public class AddCommandTest {
         ModelStub modelStub = new ModelStubWithModule(validModule);
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(AddCommand.MESSAGE_DUPLICATE_MODULE);
+        thrown.expectMessage(String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, validModule.getCode()));
         addCommand.execute(modelStub, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -114,7 +114,7 @@ public class AddCommandParserTest {
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + CREDITS_DESC_BOB + INVALID_CODE_DESC,
-                Name.MESSAGE_CONSTRAINTS);
+                Code.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + CREDITS_DESC_BOB

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -70,12 +70,14 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         /* Case: add a module with all fields same as another module in the address book except name -> rejected */
         toAdd = new ModuleBuilder(AMY).withName(VALID_NAME_BOB).build();
         command = ModuleUtil.getAddCommand(toAdd);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
+        expectedResultMessage = String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, toAdd.getCode());
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: add a module with all fields same as another module in the address book except credits -> rejected */
         toAdd = new ModuleBuilder(AMY).withCredits(VALID_CREDITS_BOB).build();
         command = ModuleUtil.getAddCommand(toAdd);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
+        expectedResultMessage = String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, toAdd.getCode());
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: add to empty address book -> added */
         deleteAllModules();
@@ -106,23 +108,26 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
 
         /* Case: add a duplicate module -> rejected */
         command = ModuleUtil.getAddCommand(HOON);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
+        expectedResultMessage = String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, HOON.getCode());
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: add a duplicate module except with different tags -> rejected */
         command = ModuleUtil.getAddCommand(HOON) + " " + PREFIX_TAG.getPrefix() + "friends";
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_MODULE);
+        expectedResultMessage = String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, HOON.getCode());
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: missing name -> rejected */
         command = AddCommand.COMMAND_WORD + CREDITS_DESC_AMY + CODE_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        expectedResultMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: missing credits -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + CODE_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: missing code -> rejected */
         command = AddCommand.COMMAND_WORD + NAME_DESC_AMY + CREDITS_DESC_AMY;
-        assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        assertCommandFailure(command, expectedResultMessage);
 
         /* Case: invalid keyword -> rejected */
         command = "adds " + ModuleUtil.getModuleDetails(toAdd);


### PR DESCRIPTION
The error messages of `AddCommand` are very vague, and do not provide
much information to help users fix incorrect command usage.

Additionally, when users simply executes the `add` command without any
parameters specified, they are greeted with "Invalid command format!".
This may cause users to feel more confused.

Let's update the success and error messages of `AddCommand` to address
the above problems by making the messages easy to understand and provide
relevant information to help them fix incorrect command usage. Also,
let's simply print `AddCommand#MESSAGE_USAGE` instead of
`CliSyntax#MESSAGE_INVALID_COMMAND_FORMAT`.