### PR TITLE
Logic/command: update `HistoryCommand#execute(...)` & error message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HistoryCommand.java
@@ -2,9 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
@@ -15,19 +16,23 @@ public class HistoryCommand extends Command {
 
     public static final String COMMAND_WORD = "history";
     public static final String MESSAGE_SUCCESS = "Entered commands (from most recent to earliest):\n%1$s";
-    public static final String MESSAGE_NO_HISTORY = "You have not yet entered any commands.";
+    public static final String MESSAGE_NO_HISTORY = "You have not entered any commands yet!";
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(history);
-        ArrayList<String> previousCommands = new ArrayList<>(history.getHistory());
+        ObservableList<String> commandHistory = history.getHistory();
 
-        if (previousCommands.isEmpty()) {
+        if (commandHistory.isEmpty()) {
             return new CommandResult(MESSAGE_NO_HISTORY);
         }
 
-        Collections.reverse(previousCommands);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, String.join("\n", previousCommands)));
+        String reversedCommandHistory = commandHistory.stream()
+                .sorted(Collections.reverseOrder())
+                .map(command -> "- " + command)
+                .collect(Collectors.joining("\n"));
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, reversedCommandHistory));
     }
 
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -10,6 +10,8 @@ import static seedu.address.testutil.TypicalModules.AMY;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
@@ -199,7 +201,11 @@ public class LogicManagerTest {
         try {
             CommandResult result = logic.execute(HistoryCommand.COMMAND_WORD);
             String expectedMessage = String.format(
-                    HistoryCommand.MESSAGE_SUCCESS, String.join("\n", expectedCommands));
+                    HistoryCommand.MESSAGE_SUCCESS, Arrays.stream(expectedCommands)
+                            .sorted(Collections.reverseOrder())
+                            .map(command -> "- " + command)
+                            .collect(Collectors.joining("\n"))
+            );
             assertEquals(expectedMessage, result.getFeedbackToUser());
         } catch (ParseException | CommandException e) {
             throw new AssertionError("Parsing and execution of HistoryCommand.COMMAND_WORD should succeed.", e);

--- a/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
@@ -20,7 +20,7 @@ public class HistoryCommandTest {
         String command1 = "clear";
         history.add(command1);
         assertCommandSuccess(new HistoryCommand(), model, history,
-                String.format(HistoryCommand.MESSAGE_SUCCESS, command1), expectedModel);
+                String.format(HistoryCommand.MESSAGE_SUCCESS, "- " + command1), expectedModel);
 
         String command2 = "randomCommand";
         String command3 = "select 1";
@@ -28,7 +28,7 @@ public class HistoryCommandTest {
         history.add(command3);
 
         String expectedMessage = String.format(HistoryCommand.MESSAGE_SUCCESS,
-                String.join("\n", command3, command2, command1));
+                String.join("\n", "- " + command3, "- " + command2, "- " + command1));
         assertCommandSuccess(new HistoryCommand(), model, history, expectedMessage, expectedModel);
     }
 


### PR DESCRIPTION
Let's update `HistoryCommand#MESSAGE_NO_HISTORY` to sound more natural,
and update `HistoryCommand#execute(...)` to print the command history in
an unordered list format.

Example:
- undo    [last command executed]
- redo    [second last command executed]