### PR TITLE
Logic: update `DeleteCommand` success and error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -13,17 +13,25 @@ import seedu.address.model.module.Module;
 
 /**
  * Deletes a module identified using it's displayed index from the address book.
+ * Deletes a {@link Module} identified using it's displayed {@link Index} in the
+ * {@link seedu.address.model.AddressBook#modules module list}.
  */
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the module identified by the index number used in the displayed module list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD + " INDEX \n"
+            + "Example: To delete the first module in the displayed module list below, you can enter: "
+            + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted Module: %1$s";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes a module in the displayed module list.\n"
+            + "To choose which module you want to delete, please include the index number "
+            + "(beside the module code) in the displayed module list.\n"
+            + FORMAT_AND_EXAMPLES;
+
+    public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Successfully deleted the module:\n%1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -17,6 +18,12 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
+            throw new ParseException(DeleteCommand.MESSAGE_USAGE);
+        }
+
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);


### PR DESCRIPTION
The error messages of `DeleteCommand` are very vague, and do not provide
much information to help users fix incorrect command usage.

Additionally, when users simply executes the `delete` command without
any parameters specified, they are greeted with "Invalid command
format!". This may cause users to feel more confused.

Let's update the success and error messages of `DeleteCommand` to
address the above problems by making the messages easy to understand and
provide relevant information to help them fix incorrect command usage.
Also, let's simply print `DeleteCommand#MESSAGE_USAGE` instead of
`CliSyntax#MESSAGE_INVALID_COMMAND_FORMAT`.