### PR TITLE
UI: add new css `WhiteTheme.css`

### DIFF
--- a/src/main/java/seedu/address/ui/DegreePlannerCard.java
+++ b/src/main/java/seedu/address/ui/DegreePlannerCard.java
@@ -1,16 +1,18 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import seedu.address.model.module.Code;
+import javafx.scene.layout.VBox;
+import seedu.address.model.module.Credits;
+import seedu.address.model.module.Module;
 import seedu.address.model.planner.DegreePlanner;
 
 /**
@@ -19,6 +21,8 @@ import seedu.address.model.planner.DegreePlanner;
 public class DegreePlannerCard extends UiPart<Region> {
 
     private static final String FXML = "DegreePlannerListCard.fxml";
+    private static final Integer MINIMUM_LOAD = 18;
+    private static final Integer OVER_LOAD = 24;
 
     public final DegreePlanner degreePlanner;
 
@@ -32,23 +36,49 @@ public class DegreePlannerCard extends UiPart<Region> {
     private Label semester;
 
     @FXML
-    private ListView<String> degreePlannerListView;
+    private Label credits;
 
-    public DegreePlannerCard(DegreePlanner degreePlanner) {
+    @FXML
+    private VBox degreePlannerListView;
+
+    public DegreePlannerCard(DegreePlanner degreePlanner, ObservableList<Module> moduleList) {
         super(FXML);
         this.degreePlanner = degreePlanner;
 
+
         year.setText("Year: " + degreePlanner.getYear().year);
+        year.setPadding(new Insets(0, 0, 0, 5));
         semester.setText(" Semester: " + degreePlanner.getSemester().plannerSemester);
 
-        year.setStyle("-fx-text-fill: white;");
-        semester.setStyle("-fx-text-fill: white;");
+        List<Module> modulesInDegreePlanner = degreePlanner.getCodes().stream()
+                .map(code -> moduleList.stream().filter(module -> module.getCode().equals(code))
+                        .findFirst().get()).collect(Collectors.toList());
 
-        ObservableList<String> modules =
-                degreePlanner.getCodes().stream().sorted(Comparator.comparing(code -> code.value)).map(Code::toString)
-                        .collect(Collectors.toCollection(FXCollections::observableArrayList));
 
-        degreePlannerListView.setItems(modules);
+        int currentCredits = modulesInDegreePlanner.stream().map(Module::getCredits).map(Credits::toString)
+                .map(Integer::parseInt).reduce(0, (totalCredits, credit) -> totalCredits + credit);
+
+        credits.setText("Total Credits: " + currentCredits + " MCs");
+        credits.setPadding(new Insets(0, 0, 0, 5));
+        credits.getStyleClass().clear();
+        if (currentCredits < MINIMUM_LOAD) {
+            credits.getStyleClass().add("orange");
+        } else if (currentCredits < OVER_LOAD) {
+            credits.getStyleClass().add("green");
+        } else {
+            credits.getStyleClass().add("red");
+        }
+
+        modulesInDegreePlanner.stream().sorted(Comparator.comparing(module -> module.getCode().toString()))
+                .forEach(module -> {
+                    VBox vbox = new VBox();
+                    VBox.setMargin(vbox, new Insets(1, 1, 1, 1));
+                    vbox.getChildren().add(new Label(
+                            module.getCode().value + " " + module.getName().toString()));
+                    vbox.getStyleClass().add("myModule");
+                    degreePlannerListView.getChildren().add(vbox);
+                });
+
         degreePlannerCardPane.setOnMouseClicked(null);
     }
 

--- a/src/main/java/seedu/address/ui/DegreePlannerListPanel.java
+++ b/src/main/java/seedu/address/ui/DegreePlannerListPanel.java
@@ -5,7 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
-
+import seedu.address.model.module.Module;
 import seedu.address.model.planner.DegreePlanner;
 
 /**
@@ -14,12 +14,15 @@ import seedu.address.model.planner.DegreePlanner;
 public class DegreePlannerListPanel extends UiPart<Region> {
 
     private static final String FXML = "DegreePlannerListPanel.fxml";
+    private ObservableList<Module> modules;
 
     @FXML
     private ListView<DegreePlanner> degreePlanners;
 
-    public DegreePlannerListPanel(ObservableList<DegreePlanner> degreePlannerList) {
+    public DegreePlannerListPanel(ObservableList<DegreePlanner> degreePlannerList,
+            ObservableList<Module> moduleList) {
         super(FXML);
+        modules = moduleList;
         degreePlanners.setItems(degreePlannerList);
         degreePlanners.setCellFactory(listView -> new DegreePlannerViewCell());
     }
@@ -37,7 +40,7 @@ public class DegreePlannerListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new DegreePlannerCard(degreePlanner).getRoot());
+                setGraphic(new DegreePlannerCard(degreePlanner, modules).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -127,7 +127,8 @@ public class MainWindow extends UiPart<Stage> {
                 logic::setSelectedModule);
         moduleListPanelPlaceholder.getChildren().add(moduleListPanel.getRoot());
 
-        degreePlannerListPanel = new DegreePlannerListPanel(logic.getFilteredDegreePlannerList());
+        degreePlannerListPanel = new DegreePlannerListPanel(logic.getFilteredDegreePlannerList(),
+                logic.getAddressBook().getModuleList());
         degreePlannerListPanelPlaceholder.getChildren().add(degreePlannerListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();

--- a/src/main/java/seedu/address/ui/RequirementCategoryCard.java
+++ b/src/main/java/seedu/address/ui/RequirementCategoryCard.java
@@ -53,12 +53,12 @@ public class RequirementCategoryCard extends UiPart<Region> {
 
         if (currentCredits == Integer.parseInt(creditsRequired)) {
             requirementCategoryCredit.getStyleClass().clear();
-            requirementCategoryCredit.getStyleClass().add("fulfilled");
+            requirementCategoryCredit.getStyleClass().add("green");
         }
 
         if (currentCredits > Integer.parseInt(creditsRequired)) {
             requirementCategoryCredit.getStyleClass().clear();
-            requirementCategoryCredit.getStyleClass().add("overAllocate");
+            requirementCategoryCredit.getStyleClass().add("red");
         }
 
         if (requirementCategory.getCodeSet().isEmpty()) {

--- a/src/main/resources/view/DegreePlannerListCard.fxml
+++ b/src/main/resources/view/DegreePlannerListCard.fxml
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-
 <StackPane fx:id="degreePlannerCardPane" xmlns="http://javafx.com/javafx/8.0.172-ea"
-           xmlns:fx="http://javafx.com/fxml/1" >
+           xmlns:fx="http://javafx.com/fxml/1">
     <VBox prefHeight="150" prefWidth="150" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1">
-        <HBox>
-            <children>
-                <Label fx:id="year"/>
-                <Label fx:id="semester"/>
-            </children>
-        </HBox>
-        <ListView styleClass="plannerCard" fx:id="degreePlannerListView" VBox.vgrow="SOMETIMES"/>
+        <VBox>
+            <HBox>
+                <Label fx:id="year" styleClass="cell_big_label"/>
+                <Label fx:id="semester" styleClass="cell_big_label"/>
+            </HBox>
+            <VBox>
+                <Label fx:id="credits" styleClass="cell_small_label"/>
+            </VBox>
+        </VBox>
+        <VBox fx:id="degreePlannerListView" alignment="CENTER_LEFT">
+        </VBox>
     </VBox>
 </StackPane>

--- a/src/main/resources/view/DegreePlannerListPanel.fxml
+++ b/src/main/resources/view/DegreePlannerListPanel.fxml
@@ -2,7 +2,7 @@
 
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
-<VBox styleClass="plannerPane" fx:id="placeHolder" xmlns="http://javafx.com/javafx/9"
+<VBox fx:id="placeHolder" xmlns="http://javafx.com/javafx/9"
       xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="degreePlanners" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: #383838;
+    -fx-background: #fffdfb;
 }
 
 .tag-selector {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -19,11 +19,11 @@
   <scene>
     <Scene>
       <stylesheets>
-        <URL value="@DarkTheme.css" />
+        <URL value="@WhiteTheme.css" />
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
+      <VBox styleClass="background">
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />

--- a/src/main/resources/view/WhiteTheme.css
+++ b/src/main/resources/view/WhiteTheme.css
@@ -1,0 +1,458 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 - AGIX | Innovative Engineering
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT 	SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+/*
+ *   This is a Material Design CSS for JavaFX
+ */
+
+/*******************************************************************************
+ *                                                                             *
+ * Root					 				                       				   *
+ *                                                                             *
+ ******************************************************************************/
+.root {
+    /* Swatch Colors - Blue*/
+    -swatch-100: #BBDEFB;
+    -swatch-200: #90CAF9;
+    -swatch-300: #64BEF6;
+    -swatch-400: #42A5F5;
+    -swatch-500: #2196F3;
+    /*default text */
+    -fx-text-base-color: rgb(100.0, 100.0, 100.0);
+    -fx-text-button-normal: -swatch-500;
+    -fx-text-button-colored: rgb(255.0, 255.0, 255.0);
+    -fx-text-button-text: rgb(100.0, 100.0, 100.0);
+    -fx-text-title-color: rgb(45.0, 45.0, 45.0);
+    -fx-text-subtitle-color: rgb(65.0, 65.0, 65.0);
+    -fx-text-control-title-color: rgb(130.0, 130.0, 130.0);
+    -fx-text-fill: -fx-text-base-color;
+    -dark: rgb(47.0, 52.0, 57.0);
+    -fx-background-color: rgb(230.0, 230.0, 230.0);
+    /*default font */
+    -fx-font-family: 'Roboto Medium';
+    -fx-font-size: 14.0px;
+    -fx-disabled-opacity: 0.6;
+    /*default colors */
+    -swatch-grey: rgb(200.0, 200.0, 200.0);
+    -swatch-dark-grey: rgb(150.0, 150.0, 150.0);
+    -swatch-light-grey: rgb(230.0, 230.0, 230.0);
+    -swatch-toolbar: rgb(245.0, 245.0, 245.0);
+    /*
+     Modena colors
+     */
+    -fx-dark-text-color: white; /* Text color when selected*/
+    -fx-mid-text-color: -fx-text-base-color;
+    -fx-light-text-color: -swatch-light-grey;
+    -fx-body-color: white;
+    /* A bright blue for the focus indicator of objects. Typically used as the
+     * first color in -fx-background-color for the "focused" pseudo-class. Also
+     * typically used with insets of -1.4 to provide a glowing effect.
+     */
+    -fx-focus-color: -swatch-400;
+    -fx-faint-focus-color: -swatch-200;
+    /* A bright blue for highlighting/accenting objects.  For example: selected
+     * text; selected items in menus, lists, trees, and tables; progress bars */
+    -fx-accent: -swatch-light-grey;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Material Design - Cards 				                       				   *
+ *                                                                             *
+ ******************************************************************************/
+.card {
+    -fx-background-color: rgb(255.0, 255.0, 255.0);
+    -fx-background-radius: 4.0;
+    -fx-effect: dropshadow(gaussian, rgb(0.0, 0.0, 0.0, 0.15), 6.0, 0.7, 0.0,
+    1.5);
+    -fx-padding: 16 16 16 16;
+}
+
+.card-title {
+    -fx-font-size: 20.0px;
+    -fx-padding: 5 0 5 0;
+}
+
+.card-title .text {
+    -fx-fill: -fx-text-title-color;
+}
+
+.card-subtitle {
+    -fx-font-size: 16.0px;
+    -fx-padding: 5 0 5 0;
+}
+
+.card-subtitle .text {
+    -fx-fill: -fx-text-subtitle-color;
+}
+
+.control-label {
+    -fx-font-size: 12.0px;
+    -fx-padding: 16 0 0 0;
+}
+
+.control-label .text {
+    -fx-fill: -fx-text-control-title-color;
+}
+
+.card-button {
+    -fx-effect: null;
+}
+
+.menu-item:focused {
+    -fx-background-color: -swatch-light-grey;
+}
+
+.menu-bar {
+    -fx-background-color: -swatch-200;
+}
+
+.menu-bar .label {
+    -fx-font-size: 12pt;
+    -fx-font-family: "Segoe UI";
+    -fx-text-fill: black;
+    -fx-opacity: 0.9;
+}
+
+
+.menu .left-container {
+    -fx-background-color: black;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Label                                                                       *
+ *                                                                             *
+ ******************************************************************************/
+.label {
+    -fx-text-fill: -fx-text-base-color;
+}
+
+.label:disabled {
+    -fx-opacity: -fx-disabled-opacity;
+}
+
+.label:show-mnemonics > .mnemonic-underline {
+    -fx-stroke: -fx-text-base-color;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * List, Tree, Table COMMON                                                    *
+ *                                                                             *
+ ******************************************************************************/
+
+
+.list-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+    -fx-background-color: -swatch-light-grey;
+}
+
+.list-cell {
+    -fx-label-padding: 0 0 0 0;
+    -fx-graphic-text-gap: 0;
+    -fx-padding: 0 0 0 0;
+}
+
+.list-cell:filled:even {
+    -fx-background-color: white;
+}
+
+.list-cell:filled:odd {
+    -fx-background-color: whitesmoke;
+}
+
+.list-cell:empty {
+    -fx-background-color: -swatch-light-grey;
+}
+
+.list-cell:filled:selected #cardPane {
+    -fx-background-color: #d8f0ea;
+    -fx-border-color: #3e7b91;
+    -fx-border-width: 1;
+}
+
+.cell_big_label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 16px;
+}
+
+.cell_small_label {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 14px;
+}
+
+.stack-pane {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Separators		                   	                                       *
+ *                                                                             *
+ ******************************************************************************/
+.separator {
+    -fx-padding: 16 -16 16 -16;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Scroll Bar			                                                       *
+ *                                                                             *
+ ******************************************************************************/
+.scroll-bar:vertical > .track-background, .scroll-bar:horizontal > .track-background {
+    -fx-background-color: -swatch-light-grey;
+    -fx-background-insets: 0.0;
+}
+
+.scroll-bar:vertical > .thumb, .scroll-bar:horizontal > .thumb {
+    -fx-background-color: -swatch-grey;
+    -fx-background-insets: 0.0;
+    -fx-background-radius: 4.0;
+}
+
+.scroll-bar > .increment-button, .scroll-bar > .decrement-button,
+.scroll-bar:hover > .increment-button, .scroll-bar:hover > .decrement-button {
+    -fx-background-color: transparent;
+}
+
+.scroll-bar > .increment-button > .increment-arrow, .scroll-bar > .decrement-button > .decrement-arrow {
+    -fx-background-color: -swatch-dark-grey;
+}
+
+.scroll-bar > .track-background {
+    -fx-background-color: transparent;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Tables								                       				   *
+ *                                                                             *
+ ******************************************************************************/
+.table-view, .tree-table-view {
+    /* Constants used throughout the tableview. */
+    -fx-table-header-border-color: transparent;
+    -fx-table-cell-border-color: -fx-box-border; /* Horizontal Lines*/
+    -fx-background-color: transparent;
+}
+
+/* The column header row is made up of a number of column-header, one for each
+   TableColumn, and a 'filler' area that extends from the right-most column
+   to the edge of the tableview, or up to the 'column control' button. */
+.table-view .filler, .tree-table-view .filler, .table-view .column-header,
+.tree-table-view .column-header {
+    -fx-size: 65;
+    -fx-border-style: null;
+    -fx-border-color: -swatch-grey;
+    -fx-border-width: 0 0 2 0;
+    -fx-background-color: transparent;
+}
+
+.table-view .show-hide-columns-button, .tree-table-view .show-hide-columns-button {
+    -fx-background-color: transparent;
+}
+
+.table-view .column-header .label, .table-view .filler .label,
+.table-view .column-drag-header .label, .tree-table-view .column-header .label,
+.tree-table-view .filler .label, .tree-table-view .column-drag-header .label {
+    -fx-alignment: CENTER_LEFT;
+}
+
+.table-view .column-header-background, .tree-table-view .column-header-background {
+    -fx-background-color: transparent;
+}
+
+.table-row-cell, .tree-table-row-cell {
+    -fx-cell-size: 40px;
+}
+
+.table-cell {
+    -fx-border-color: transparent; /* Vertical Lines*/
+    -fx-border-width: 1;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Text, Text field & Text area                                                *
+ *                                                                             *
+ ******************************************************************************/
+.text {
+    -fx-font-smoothing-type: gray;
+}
+
+.text-area, .text-field {
+    -fx-background-color: transparent;
+    -fx-background-radius: 2.0;
+    -fx-padding: 0.5em 0.5em 0.5em 0.1em;
+    -fx-border-color: -swatch-grey;
+    -fx-border-width: 0 0 2 0;
+    -fx-prompt-text-fill: derive(-dark, 50.0%);
+    -fx-highlight-fill: rgb(94.0, 203.0, 234.0);
+}
+
+.text-area .text, .text-field > * > .text {
+    -fx-effect: null;
+    -fx-fill: -dark;
+}
+
+.text-area {
+    -fx-padding: 0.15em;
+}
+
+.text-area .content {
+    -fx-padding: 0.7em;
+    -fx-border-width: 0.0;
+    -fx-background-color: transparent;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Tool bar	& Menu bar		                       			  				   *
+ *                                                                             *
+ ******************************************************************************/
+.menu-bar { /* top */
+    -fx-background-color: -swatch-toolbar;
+    -fx-border-width: 0 0 2 0;
+    -fx-border-color: -swatch-grey;
+    -fx-min-height: 48;
+    -fx-alignment: CENTER_LEFT;
+}
+
+#cardPane {
+    -fx-background-color: transparent;
+    -fx-border-width: 0;
+}
+
+#commandTypeLabel {
+    -fx-font-size: 11px;
+    -fx-text-fill: #F70D1A;
+}
+
+#commandTextField {
+    -fx-background-color: #fff;
+    -fx-padding: 0.5em 0.5em 0.5em 0.5em;
+    -fx-border-color: -swatch-grey;
+    -fx-border-width: 0 0 2 0;
+    -fx-prompt-text-fill: derive(-dark, 50.0%);
+    -fx-highlight-fill: rgb(94.0, 203.0, 234.0);
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 12pt;
+}
+
+#commandTextDisplay {
+    -fx-background-color: #fff;
+    -fx-padding: 0.5em 0.5em 0.5em 0.5em;
+    -fx-border-color: -swatch-grey;
+    -fx-border-width: 0 0 2 0;
+    -fx-prompt-text-fill: derive(-dark, 50.0%);
+    -fx-highlight-fill: rgb(94.0, 203.0, 234.0);
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 12pt;
+}
+
+#resultDisplay .content {
+    -fx-background-color: transparent;
+    -fx-prompt-text-fill: derive(-dark, 50.0%);
+    -fx-highlight-fill: rgb(94.0, 203.0, 234.0);
+}
+
+#resultDisplay:focused {
+    -fx-border-color: -swatch-grey;
+}
+
+.result-display {
+    -fx-background-color: #fff;
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 12pt;
+}
+
+.result-display .label {
+    -fx-text-fill: black;
+}
+
+#degreePlannerListView .list-cell {
+    -fx-padding: 0 0 0 5;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Tags		                       			  				   				   *
+ *                                                                             *
+ ******************************************************************************/
+
+#tags, #codes {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#tags .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e7b91;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+
+.red {
+    -fx-text-fill: #ff7675;
+}
+
+.orange {
+    -fx-text-fill: #FF7F11;
+}
+
+.green {
+    -fx-text-fill: #43845F;
+}
+
+#codes .label {
+    -fx-text-fill: white;
+    -fx-background-color: #47996B;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 13;
+}
+
+.noModules {
+    -fx-fill: black;
+}
+
+.background {
+    -fx-background-color: derive(#f5f5f5, 20%);
+    background-color: white; /* Used in the default.html file */
+}
+
+.myModule .label {
+    -fx-background-color: #D35934;
+    -fx-padding: 10 10 10 10;
+    -fx-background-radius: 2;
+    -fx-font-size: 13;
+    -fx-text-fill: white;
+    -fx-pref-width: 1000;
+}


### PR DESCRIPTION
The black theme was created for `AddressBook`, as our application have
morph from `AddressBook` to `PlanWithEase`, we should have our own
style to allow our users to remember our product.

Let's overhaul the UI and give our application a new look and:
* display module name in degree planner
* display total credits in degree planner
* cascade all changes needed to allow our application to look nicer.

Screenshot of our application as shown below.

![image](https://user-images.githubusercontent.com/2564679/55294600-a7b2f080-5436-11e9-85f9-456e6b007833.png)
