### PR TITLE
Logic/parser: refactor `ParserUtil` methods

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,9 +7,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -53,14 +53,6 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Module module = new Module(name, credits, code, tagList, corequisiteList);
         return new AddCommand(module);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -22,6 +23,15 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -77,7 +77,6 @@ public class ParserUtil {
         return new Credits(trimmedCredits);
     }
 
-
     /**
      * Parses a {@code String code} into an {@code Code}.
      * Leading and trailing whitespaces will be trimmed.
@@ -163,15 +162,11 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code Collection<String> corequisites} into a {@code Set<Code>}.
+     * Parses {@code Collection<String> corequisites} into a {@code Set<Code>}.<br>
+     * Syntactic sugar for {@link #parseCodes} method.
      */
     public static Set<Code> parseCorequisites(Collection<String> corequisites) throws ParseException {
-        requireNonNull(corequisites);
-        final Set<Code> corequisitesSet = new HashSet<>();
-        for (String corequisite : corequisites) {
-            corequisitesSet.add(parseCode(corequisite));
-        }
-        return corequisitesSet;
+        return parseCodes(corequisites);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/PlannerAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PlannerAddCommandParser.java
@@ -4,9 +4,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.PlannerAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -39,13 +39,4 @@ public class PlannerAddCommandParser implements Parser<PlannerAddCommand> {
 
         return new PlannerAddCommand(year, semester, codes);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/PlannerMoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PlannerMoveCommandParser.java
@@ -5,8 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
-
-import java.util.stream.Stream;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.address.logic.commands.PlannerMoveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -39,13 +38,4 @@ public class PlannerMoveCommandParser implements Parser<PlannerMoveCommand> {
 
         return new PlannerMoveCommand(year, semester, code);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/RequirementAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RequirementAddCommandParser.java
@@ -3,9 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.RequirementAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,13 +35,4 @@ public class RequirementAddCommandParser {
 
         return new RequirementAddCommand(name, codeList);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/RequirementRemoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RequirementRemoveCommandParser.java
@@ -3,9 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CODE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Set;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.RequirementRemoveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,13 +35,4 @@ public class RequirementRemoveCommandParser implements Parser<RequirementRemoveC
 
         return new RequirementRemoveCommand(name, codeList);
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
 }


### PR DESCRIPTION
There is code duplication in command parsers.

For instance, many command parsers (such as `AddCommandParser`,
`PlannerAddCommandParser`, `RequriementRemoveCommandParser`) have the
same `arePrefixesPresent(...)` implementation.

Additionally, `ParserUtil#parseCorequisites(...)` is simply a syntactic 
sugar for `ParserUtil#parseCodes(...)`, and has the same implementation
as `ParserUtil#parseCodes(...)`.

Let's reduce code duplication by updating `ParserUtil` to:
* extract `arePrefixesPresent(...)` to `ParserUtil`
* make `parseCorequisites(...)` call `parseCodes(...)` internally