### PR TITLE
RequirementCategory: implement `requirement_move` command 

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/RequirementMoveCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementMoveCommand.java
@@ -1,0 +1,163 @@
+package pwe.planner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.model.util.RequirementCategoryUtil.getRequirementCategoryWithCodeAdded;
+import static pwe.planner.model.util.RequirementCategoryUtil.getRequirementCategoryWithCodeRemoved;
+import static pwe.planner.model.util.RequirementCategoryUtil.getRequirementCategoryWithCodesAdded;
+import static pwe.planner.model.util.RequirementCategoryUtil.getRequirementCategoryWithCodesRemoved;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javafx.collections.ObservableList;
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.logic.commands.exceptions.CommandException;
+import pwe.planner.model.Model;
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Name;
+import pwe.planner.model.requirement.RequirementCategory;
+
+/**
+ * Moves modules from a requirement category to another requirement category
+ */
+public class RequirementMoveCommand extends Command {
+
+    public static final String COMMAND_WORD = "requirement_move";
+
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD + ' '
+            + PREFIX_NAME + "NAME "
+            + PREFIX_CODE + "CODE "
+            + "[" + PREFIX_CODE + "CODE]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "Computing Foundation "
+            + PREFIX_CODE + "CS1010";
+
+    // General command help details
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Moves module(s) from one"
+            + " requirement category to another. \n"
+            + FORMAT_AND_EXAMPLES;
+
+    // Command success message
+    public static final String MESSAGE_SUCCESS = "Successfully moved module(s) (%1$s) to requirement category %2$s!";
+
+    // Command failure messages
+    public static final String MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY =
+            "You cannot specify a requirement category (%1$s) that does not exist!\n"
+            + "Perhaps you misspelled the name of the requirement category?\n"
+            + "[Tip] You may want to refer to the requirement category list to see the requirement categories"
+            + " in the application using the \"requirement_list\" command!";
+
+    public static final String MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY =
+            "You cannot move module(s) (%1$s) that does not exist in any requirement category!\n"
+            + "Perhaps you were trying to add modules into the requirement category?\n"
+            + "[Tip] You can try adding the module into the requirement category using the "
+            + "\"requirement_add\" command!";
+
+    public static final String MESSAGE_NONEXISTENT_CODE = "You cannot specify module(s) (%1$s) that does not exist!\n"
+            + "Perhaps you were trying to add modules into the application?\n"
+            + "[Tip] You may want to add the module into the module list first using the \"add\" command.\n"
+            + "Afterwards, you can add the module into the requirement category using the "
+            + "\"requirement_add\" command!";
+
+    private final Name toFind;
+    private final Set<Code> toMove = new HashSet<>();
+
+    /**
+     * Creates an RequirementMoveCommand to add the specified {@code RequirementMoveCommand}
+     */
+    public RequirementMoveCommand(Name name, Set<Code> codeSet) {
+        requireAllNonNull(name, codeSet);
+
+        this.toFind = name;
+        this.toMove.addAll(codeSet);
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        ObservableList<RequirementCategory> requirementCategories = model.getApplication().getRequirementCategoryList();
+        RequirementCategory destinationRequirementCategory = model.getRequirementCategory(toFind);
+
+        if (destinationRequirementCategory == null) {
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY, toFind));
+        }
+
+        List<Code> nonExistentCodes = toMove.stream().filter(code -> !model.hasModuleCode(code))
+                .collect(Collectors.toList());
+
+        if (!nonExistentCodes.isEmpty()) {
+            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
+        }
+
+        List<Code> codeNotInAnyRequirementCategory = toMove.stream().filter(code -> requirementCategories.stream()
+                .noneMatch(requirementCategory -> requirementCategory.getCodeSet()
+                .contains(code))).collect(Collectors.toList());
+
+        if (!codeNotInAnyRequirementCategory.isEmpty()) {
+            String codeNotInAnyRequirementCategoryErrorMessage = codeNotInAnyRequirementCategory.stream()
+                    .map(Code::toString).collect(Collectors.joining(", "));
+            throw new CommandException(String.format(MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
+                    codeNotInAnyRequirementCategoryErrorMessage));
+        }
+
+        RequirementCategory singleSourceRequirementCategory = requirementCategories.stream()
+                .filter(requirementCategory -> requirementCategory.getCodeSet()
+                .containsAll(toMove)).findFirst().orElse(null);
+
+        //If all codes to be moved is from a requirement category only, all the codes can be moved together
+        if (singleSourceRequirementCategory != null) {
+            //Check if destination code contains codes to move for edge cases
+            if (!destinationRequirementCategory.getCodeSet().containsAll(toMove)) {
+                RequirementCategory editedSourceRequirementCategory =
+                        getRequirementCategoryWithCodesRemoved(singleSourceRequirementCategory, toMove);
+                RequirementCategory editedDestinationRequirementCategory =
+                        getRequirementCategoryWithCodesAdded(destinationRequirementCategory, toMove);
+
+                model.setRequirementCategory(singleSourceRequirementCategory, editedSourceRequirementCategory);
+                model.setRequirementCategory(destinationRequirementCategory, editedDestinationRequirementCategory);
+            }
+        } else {
+            for (Code code : toMove) {
+                //Check if destination code contains codes to move for edge cases
+                if (!destinationRequirementCategory.getCodeSet().contains(code)) {
+                    RequirementCategory sourceRequirementCategory = requirementCategories.stream()
+                            .filter(reqCat -> reqCat.getCodeSet().contains(code)).findFirst().orElse(null);
+
+                    RequirementCategory editedSourceRequirementCategory =
+                            getRequirementCategoryWithCodeRemoved(sourceRequirementCategory, code);
+                    RequirementCategory editedDestinationRequirementCategory =
+                            getRequirementCategoryWithCodeAdded(destinationRequirementCategory, code);
+
+                    model.setRequirementCategory(sourceRequirementCategory, editedSourceRequirementCategory);
+                    model.setRequirementCategory(destinationRequirementCategory, editedDestinationRequirementCategory);
+
+                    //reinitialize the updated destination requirement category
+                    destinationRequirementCategory = model.getRequirementCategory(toFind);
+                }
+            }
+        }
+
+        String codesMoved = toMove.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        model.commitApplication();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, codesMoved, destinationRequirementCategory.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RequirementMoveCommand // instanceof handles nulls
+                && toFind.equals(((RequirementMoveCommand) other).toFind)
+                && toMove.equals(((RequirementMoveCommand) other).toMove));
+    }
+
+}

--- a/src/main/java/pwe/planner/logic/parser/CommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/CommandParser.java
@@ -24,6 +24,7 @@ import pwe.planner.logic.commands.PlannerShowCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
+import pwe.planner.logic.commands.RequirementMoveCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.logic.commands.ResetCommand;
 import pwe.planner.logic.commands.SelectCommand;
@@ -88,6 +89,9 @@ public class CommandParser {
 
         case RequirementListCommand.COMMAND_WORD:
             return new RequirementListCommand();
+
+        case RequirementMoveCommand.COMMAND_WORD:
+            return new RequirementMoveCommandParser().parse(arguments);
 
         case RequirementRemoveCommand.COMMAND_WORD:
             return new RequirementRemoveCommandParser().parse(arguments);

--- a/src/main/java/pwe/planner/logic/parser/RequirementMoveCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/RequirementMoveCommandParser.java
@@ -1,0 +1,47 @@
+package pwe.planner.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.ParserUtil.arePrefixesPresent;
+import static pwe.planner.logic.parser.ParserUtil.parseCodes;
+import static pwe.planner.logic.parser.ParserUtil.parseName;
+
+import java.util.Set;
+
+import pwe.planner.logic.commands.RequirementMoveCommand;
+import pwe.planner.logic.parser.exceptions.ParseException;
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Name;
+
+/**
+ * Parses input arguments and creates a new RequirementMoveCommand object
+ */
+public class RequirementMoveCommandParser implements Parser<RequirementMoveCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the RequirementMoveCommand
+     * and returns an RequirementMoveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RequirementMoveCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
+            throw new ParseException(RequirementMoveCommand.MESSAGE_USAGE);
+        }
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RequirementMoveCommand.MESSAGE_USAGE));
+        }
+
+        Name name = parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Set<Code> codeSet = parseCodes(argMultimap.getAllValues(PREFIX_CODE));
+
+        return new RequirementMoveCommand(name, codeSet);
+    }
+}

--- a/src/main/java/pwe/planner/model/util/RequirementCategoryUtil.java
+++ b/src/main/java/pwe/planner/model/util/RequirementCategoryUtil.java
@@ -1,0 +1,68 @@
+package pwe.planner.model.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import pwe.planner.model.module.Code;
+import pwe.planner.model.requirement.RequirementCategory;
+
+/**
+ * A utility class for RequirementCategory.
+ */
+public class RequirementCategoryUtil {
+
+    /**
+     * Returns a new requirement category object with the specified code {@code toMove} removed from the
+     * requirement category provided {@code reqCat}
+     */
+    public static RequirementCategory getRequirementCategoryWithCodeRemoved(RequirementCategory reqCat, Code toMove) {
+        Set<Code> newCodeSet = new HashSet<>(reqCat.getCodeSet());
+        newCodeSet.remove(toMove);
+        RequirementCategory requirementCategory = new RequirementCategory(reqCat.getName(), reqCat.getCredits(),
+                newCodeSet);
+
+        return requirementCategory;
+    }
+
+    /**
+     * Returns a new requirement category object with the specified code set {@code toMove} removed from the
+     * requirement category provided {@code reqCat}
+     */
+    public static RequirementCategory getRequirementCategoryWithCodesRemoved(RequirementCategory reqCat,
+            Set<Code> setToMove) {
+        Set<Code> newCodeSet = new HashSet<>(reqCat.getCodeSet());
+        newCodeSet.removeAll(setToMove);
+        RequirementCategory requirementCategory = new RequirementCategory(reqCat.getName(), reqCat.getCredits(),
+                newCodeSet);
+
+        return requirementCategory;
+    }
+
+    /**
+     * Returns a new requirement category object with the specified code {@code toMove} added from the
+     * requirement category provided {@code reqCat}
+     */
+    public static RequirementCategory getRequirementCategoryWithCodeAdded(RequirementCategory reqCat, Code toMove) {
+        Set<Code> newCodeSet = new HashSet<>(reqCat.getCodeSet());
+        newCodeSet.add(toMove);
+        RequirementCategory requirementCategory = new RequirementCategory(reqCat.getName(), reqCat.getCredits(),
+                newCodeSet);
+
+        return requirementCategory;
+    }
+
+    /**
+     * Returns a new requirement category object with the specified code set {@code toMove} added from the
+     * requirement category provided {@code reqCat}
+     */
+    public static RequirementCategory getRequirementCategoryWithCodesAdded(RequirementCategory reqCat,
+            Set<Code> setToMove) {
+        Set<Code> newCodeSet = new HashSet<>(reqCat.getCodeSet());
+        newCodeSet.addAll(setToMove);
+        RequirementCategory requirementCategory = new RequirementCategory(reqCat.getName(), reqCat.getCredits(),
+                newCodeSet);
+
+        return requirementCategory;
+    }
+
+}

--- a/src/test/data/JsonSerializableApplicationTest/typicalRequirementCategoryList.json
+++ b/src/test/data/JsonSerializableApplicationTest/typicalRequirementCategoryList.json
@@ -22,7 +22,7 @@
   }, {
     "name" : "Mathematics",
     "credits" : "12",
-    "codeList" : [ ]
+    "codeList" : [ "CS1231" ]
   }, {
     "name" : "General Education",
     "credits" : "20",

--- a/src/test/java/pwe/planner/logic/commands/RequirementMoveCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementMoveCommandTest.java
@@ -1,0 +1,349 @@
+package pwe.planner.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
+import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.model.Model;
+import pwe.planner.model.ModelManager;
+import pwe.planner.model.UserPrefs;
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Name;
+import pwe.planner.model.requirement.RequirementCategory;
+import pwe.planner.model.util.RequirementCategoryUtil;
+import pwe.planner.storage.JsonSerializableApplication;
+
+public class RequirementMoveCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+    private Model model;
+
+    @Before
+    public void setUp() throws IllegalValueException {
+        model = new ModelManager(new JsonSerializableApplication(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+    }
+
+    @Test
+    public void constructor_nullInputs_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        new RequirementMoveCommand(null, null);
+    }
+
+    @Test
+    public void execute_nonExistentRequirementCategory_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS1231"));
+        Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(nonExistentRequirementCategoryName, validCodeSet);
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                nonExistentRequirementCategoryName);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_nonExistentCodeInApplication_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS9999"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_codeNotInAnyRequirementCategory_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2040C"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY, formattedCodeString);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeWithNonExistentCodeInApplication_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS9999"), new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+
+        Set<Code> invalidCodeSet = Set.of(new Code("CS9999"));
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeWithCodeNotInAnyRequirementCategory_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2040C"), new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+
+        Set<Code> invalidCodeSet = Set.of(new Code("CS2040C"));
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY, formattedCodeString);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeAndCodeNotInAnyRequirementCategoryAndNonExistentRequirementCategory_throwsException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2040C"), new Code("CS2100"));
+        Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(nonExistentRequirementCategoryName, validCodeSet);
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                nonExistentRequirementCategoryName);
+
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeWithNonExistentCodeInAppAndNonExistentRequirementCategory_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS9999"), new Code("CS2100"));
+        Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(nonExistentRequirementCategoryName, validCodeSet);
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                nonExistentRequirementCategoryName);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeWithCodeNotInAnyRequirementCategoryAndApplication_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2040C"), new Code("CS2100"), new Code("CS9999"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+
+        Set<Code> invalidCodeSet = Set.of(new Code("CS9999"));
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_multiCodeWithAllInvalid_throwsCommandException() {
+        Set<Code> validCodeSet = Set.of(new Code("CS9999"), new Code("CS2040C"));
+        Name requirementCategoryName = new Name("Computing 123");
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
+                requirementCategoryName);
+
+        assertCommandFailure(requirementMoveCommand, model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_moveCodeToOtherRequirementCategory_success() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
+
+        Name sourceReqCatName = new Name("Computing Foundation");
+        Name destinationReqCatName = new Name("Computing Breadth");
+
+        RequirementCategory sourceReqCat = model.getRequirementCategory(sourceReqCatName);
+        RequirementCategory destinationReqCat = model.getRequirementCategory(destinationReqCatName);
+
+        RequirementCategory editedSourceReqCat = RequirementCategoryUtil
+                .getRequirementCategoryWithCodesRemoved(sourceReqCat, validCodeSet);
+        RequirementCategory editedDestinationReqCat = RequirementCategoryUtil
+                .getRequirementCategoryWithCodesAdded(destinationReqCat, validCodeSet);
+
+        Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
+        expectedModel.setRequirementCategory(sourceReqCat, editedSourceReqCat);
+        expectedModel.setRequirementCategory(destinationReqCat, editedDestinationReqCat);
+        expectedModel.commitApplication();
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(destinationReqCatName, validCodeSet);
+
+        String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString,
+                destinationReqCatName);
+
+        assertCommandSuccess(requirementMoveCommand, model, commandHistory, expectedMessage , expectedModel);
+    }
+
+    @Test
+    public void execute_moveCodeToSameRequirementCategory_success() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
+
+        Name destinationReqCatName = new Name("Computing Foundation");
+
+        Model expectedModel = model;
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(destinationReqCatName, validCodeSet);
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString, destinationReqCatName);
+
+        assertCommandSuccess(requirementMoveCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_moveCodesFromMultipleSource_success() {
+        Set<Code> validCodeSet = Set.of(new Code("CS1231"), new Code("CS2100"));
+
+        Set<Code> sourceCodeSet1 = Set.of(new Code("CS2100"));
+
+        Set<Code> sourceCodeSet2 = Set.of(new Code("CS1231"));
+
+        Name sourceReqCatName1 = new Name("Computing Foundation");
+        Name sourceReqCatName2 = new Name("Mathematics");
+        Name destinationReqCatName = new Name("Computing Breadth");
+
+        RequirementCategory sourceReqCat1 = model.getRequirementCategory(sourceReqCatName1);
+        RequirementCategory sourceReqCat2 = model.getRequirementCategory(sourceReqCatName2);
+        RequirementCategory destinationReqCat = model.getRequirementCategory(destinationReqCatName);
+
+        RequirementCategory editedSourceReqCat = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesRemoved(sourceReqCat1, sourceCodeSet1);
+        RequirementCategory editedSourceReqCat2 = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesRemoved(sourceReqCat2, sourceCodeSet2);
+        RequirementCategory editedDestinationReqCat = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesAdded(destinationReqCat, validCodeSet);
+
+        Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
+        expectedModel.setRequirementCategory(sourceReqCat1, editedSourceReqCat);
+        expectedModel.setRequirementCategory(sourceReqCat2, editedSourceReqCat2);
+        expectedModel.setRequirementCategory(destinationReqCat, editedDestinationReqCat);
+        expectedModel.commitApplication();
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(destinationReqCatName, validCodeSet);
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString, destinationReqCatName);
+
+        assertCommandSuccess(requirementMoveCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_moveCodesWithSameSourceAndDestination_success() {
+        Set<Code> validCodeSet = Set.of(new Code("CS1231"), new Code("CS2100"));
+
+        Set<Code> sourceCodeSet1 = Set.of(new Code("CS2100"));
+
+        Set<Code> sourceCodeSet2 = Set.of(new Code("CS1231"));
+
+        Name sourceReqCatName1 = new Name("Computing Foundation");
+        Name sourceReqCatName2 = new Name("Mathematics");
+        Name destinationReqCatName = new Name("Computing Foundation");
+
+        RequirementCategory sourceReqCat1 = model.getRequirementCategory(sourceReqCatName1);
+        RequirementCategory sourceReqCat2 = model.getRequirementCategory(sourceReqCatName2);
+
+        RequirementCategory editedSourceReqCat = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesRemoved(sourceReqCat1, sourceCodeSet1);
+        RequirementCategory editedSourceReqCat2 = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesRemoved(sourceReqCat2, sourceCodeSet2);
+
+        Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
+        expectedModel.setRequirementCategory(sourceReqCat1, editedSourceReqCat);
+        expectedModel.setRequirementCategory(sourceReqCat2, editedSourceReqCat2);
+
+        RequirementCategory destinationReqCat = expectedModel.getRequirementCategory(destinationReqCatName);
+        RequirementCategory editedDestinationReqCat = RequirementCategoryUtil
+                        .getRequirementCategoryWithCodesAdded(destinationReqCat, validCodeSet);
+        expectedModel.setRequirementCategory(destinationReqCat, editedDestinationReqCat);
+        expectedModel.commitApplication();
+
+        RequirementMoveCommand requirementMoveCommand =
+                new RequirementMoveCommand(destinationReqCatName, validCodeSet);
+
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        String expectedMessage =
+                String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString, destinationReqCatName);
+
+        assertCommandSuccess(requirementMoveCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_equals() {
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+
+        Set<Code> codeSetToCompare = Set.of(new Code("CS1010"));
+        Name requirementCategoryNameToCompare = new Name("Mathematics");
+
+        RequirementMoveCommand commandBaseline = new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+        RequirementMoveCommand commandToCompare =
+                new RequirementMoveCommand(requirementCategoryNameToCompare, codeSetToCompare);
+
+        //same object -> returns true
+        assertTrue(commandBaseline.equals(commandBaseline));
+
+        //different objects, same values -> returns true
+        RequirementMoveCommand commandBaselineCopy = new RequirementMoveCommand(requirementCategoryName, validCodeSet);
+        assertTrue(commandBaseline.equals(commandBaselineCopy));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(commandToCompare));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(1));
+    }
+
+
+}

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -11,7 +11,6 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
 import static pwe.planner.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,6 +35,7 @@ import pwe.planner.logic.commands.PlannerShowCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
+import pwe.planner.logic.commands.RequirementMoveCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.logic.commands.ResetCommand;
 import pwe.planner.logic.commands.SelectCommand;
@@ -174,8 +174,7 @@ public class CommandParserTest {
     @Test
     public void parseCommand_requirementAdd() throws Exception {
         Name name = new Name("Computing Foundation");
-        Set<Code> codeSet = new HashSet<>();
-        codeSet.add(new Code("CS1010"));
+        Set<Code> codeSet = Set.of(new Code("CS1010"));
         RequirementAddCommand command = (RequirementAddCommand)
                 parser.parseCommand(RequirementUtil.getRequirementAddCommand(name, codeSet));
         assertEquals(new RequirementAddCommand(name, codeSet), command);
@@ -187,13 +186,21 @@ public class CommandParserTest {
     }
 
     @Test
+    public void parseCommand_requirementMove() throws Exception {
+        Set<Code> codeSet = Set.of(new Code("CS2100"));
+        RequirementMoveCommand command = (RequirementMoveCommand) parser.parseCommand(
+                RequirementMoveCommand.COMMAND_WORD + " " + PREFIX_NAME + "Computing Breadth " + PREFIX_CODE
+                        + "CS2100");
+        assertEquals(new RequirementMoveCommand(new Name("Computing Breadth"), codeSet), command);
+    }
+
+    @Test
     public void parseCommand_requirementRemove() throws Exception {
-        Name name = new Name("Computing Foundation");
-        Set<Code> codeSet = new HashSet<>();
-        codeSet.add(new Code("CS1010"));
+        Set<Code> codeSet = Set.of(new Code("CS1010"));
         RequirementRemoveCommand command = (RequirementRemoveCommand)
-                parser.parseCommand(RequirementUtil.getRequirementRemoveCommand(name, codeSet));
-        assertEquals(new RequirementRemoveCommand(name, codeSet), command);
+                parser.parseCommand(RequirementUtil.getRequirementRemoveCommand(
+                        new Name("Computing Foundation"), codeSet));
+        assertEquals(new RequirementRemoveCommand(new Name("Computing Foundation"), codeSet), command);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/RequirementMoveCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/RequirementMoveCommandParserTest.java
@@ -1,0 +1,85 @@
+package pwe.planner.logic.parser;
+
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+import pwe.planner.logic.commands.RequirementMoveCommand;
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Name;
+
+public class RequirementMoveCommandParserTest {
+
+    private RequirementMoveCommandParser parser = new RequirementMoveCommandParser();
+
+    @Test
+    public void parse_nullValue_failure() {
+        //empty input
+        assertParseFailure(parser, "", RequirementMoveCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid format
+        assertParseFailure(parser, " INVALID INPUT", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RequirementMoveCommand.MESSAGE_USAGE));
+
+        // invalid name format
+        assertParseFailure(parser, " " + PREFIX_NAME + "  " + PREFIX_CODE + "CS1010 ",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid name format
+        assertParseFailure(parser, " " + PREFIX_CODE + "CS1010 " + " " + PREFIX_NAME ,
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid code format
+        assertParseFailure(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "1231",
+                Code.MESSAGE_CONSTRAINTS);
+
+        // invalid code format
+        assertParseFailure(parser, " " + PREFIX_CODE + "1231 " + PREFIX_NAME + "Computing Foundation ",
+                Code.MESSAGE_CONSTRAINTS);
+
+        // invalid name and code format
+        assertParseFailure(parser, " " + PREFIX_NAME + " " + PREFIX_CODE + "1231",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid name and code format
+        assertParseFailure(parser, " " + PREFIX_CODE + "1231 " + PREFIX_NAME + " ",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + " " + PREFIX_NAME + "Computing Foundation "
+                + PREFIX_CODE + "CS1231", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RequirementMoveCommand.MESSAGE_USAGE));
+
+    }
+
+    @Test
+    public void parse_validArgs_returnsRequirementRemoveCommand() {
+        Set<Code> validCodeSet = Set.of(new Code("CS1010"));
+        RequirementMoveCommand expectedRequirementMoveCommand =
+                new RequirementMoveCommand(new Name("Computing Foundation"), validCodeSet);
+
+        //valid command
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementMoveCommand);
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Computing Foundation "
+                        + PREFIX_CODE + "CS1010 ", expectedRequirementMoveCommand);
+
+        // multiple requirement categories specified - last requirement category accepted
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Mathematics " + PREFIX_NAME
+                + "Computing Foundation " + PREFIX_CODE + "CS1010", expectedRequirementMoveCommand);
+
+    }
+}

--- a/src/test/java/pwe/planner/testutil/RequirementUtil.java
+++ b/src/test/java/pwe/planner/testutil/RequirementUtil.java
@@ -26,7 +26,6 @@ public class RequirementUtil {
         return sb.toString();
     }
 
-
     /**
      * Returns an add command string for adding the {@code code}.
      */

--- a/src/test/java/pwe/planner/testutil/TypicalRequirementCategories.java
+++ b/src/test/java/pwe/planner/testutil/TypicalRequirementCategories.java
@@ -9,39 +9,55 @@ import pwe.planner.model.Application;
 import pwe.planner.model.requirement.RequirementCategory;
 
 /**
- * A utility class containing a list of {@code Module} objects to be used in tests.
+ * A utility class containing a list of {@code RequirementCategory} objects to be used in tests.
  */
 public class TypicalRequirementCategories {
 
-    public static final RequirementCategory COMPUTING_FOUNDATION =
-            new RequirementCategoryBuilder().withName("Computing Foundation")
-                    .withCredits("36").withCodes("CS2100").build();
-    public static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS =
-            new RequirementCategoryBuilder().withName("Information Security Requirements")
-                    .withCredits("20").build();
-    public static final RequirementCategory INFORMATION_SECURITY_ELECTIVES =
-            new RequirementCategoryBuilder().withName("Information Security Electives")
-                    .withCredits("12").build();
-    public static final RequirementCategory COMPUTING_BREADTH =
-            new RequirementCategoryBuilder().withName("Computing Breadth")
-                    .withCredits("20").build();
-    public static final RequirementCategory IT_PROFESSIONALISM =
-            new RequirementCategoryBuilder().withName("IT Professionalism")
-                    .withCredits("8").build();
-    public static final RequirementCategory MATHEMATICS =
-            new RequirementCategoryBuilder().withName("Mathematics")
-                    .withCredits("12").build();
-    public static final RequirementCategory GENERAL_EDUCATION =
-            new RequirementCategoryBuilder().withName("General Education")
-                    .withCredits("20").build();
-    public static final RequirementCategory UNRESTRICTED_ELECTIVES =
-            new RequirementCategoryBuilder().withName("Unrestricted Electives")
-                    .withCredits("12").build();
+    public static final RequirementCategory COMPUTING_FOUNDATION = new RequirementCategoryBuilder()
+            .withName("Computing Foundation")
+            .withCredits("36")
+            .withCodes("CS2100")
+            .build();
+
+    public static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategoryBuilder()
+            .withName("Information Security Requirements")
+            .withCredits("20")
+            .build();
+
+    public static final RequirementCategory INFORMATION_SECURITY_ELECTIVES = new RequirementCategoryBuilder()
+            .withName("Information Security Electives")
+            .withCredits("12")
+            .build();
+    public static final RequirementCategory COMPUTING_BREADTH = new RequirementCategoryBuilder()
+            .withName("Computing Breadth")
+            .withCredits("20")
+            .build();
+
+    public static final RequirementCategory IT_PROFESSIONALISM = new RequirementCategoryBuilder()
+            .withName("IT Professionalism")
+            .withCredits("8")
+            .build();
+
+    public static final RequirementCategory MATHEMATICS = new RequirementCategoryBuilder()
+            .withName("Mathematics")
+            .withCredits("12")
+            .withCodes("CS1231")
+            .build();
+
+    public static final RequirementCategory GENERAL_EDUCATION = new RequirementCategoryBuilder()
+            .withName("General Education")
+            .withCredits("20")
+            .build();
+
+    public static final RequirementCategory UNRESTRICTED_ELECTIVES = new RequirementCategoryBuilder()
+            .withName("Unrestricted Electives")
+            .withCredits("12")
+            .build();
 
     private TypicalRequirementCategories() {} // prevents instantiation
 
     /**
-     * Returns an {@code Application} with all the typical modules.
+     * Returns an {@code Application} with all the typical requirement categories.
      */
     public static ObservableList<RequirementCategory> getTypicalRequirementCategoriesList() {
         Application requirementCategoryList = new Application();
@@ -52,8 +68,8 @@ public class TypicalRequirementCategories {
     }
 
     public static List<RequirementCategory> getTypicalRequirementCategories() {
-        return new ArrayList<>(
-                Arrays.asList(COMPUTING_FOUNDATION, INFORMATION_SECURITY_REQUIREMENTS, INFORMATION_SECURITY_ELECTIVES,
-                        COMPUTING_BREADTH, IT_PROFESSIONALISM, MATHEMATICS, GENERAL_EDUCATION, UNRESTRICTED_ELECTIVES));
+        return new ArrayList<>(Arrays.asList(COMPUTING_FOUNDATION, INFORMATION_SECURITY_REQUIREMENTS,
+                INFORMATION_SECURITY_ELECTIVES, COMPUTING_BREADTH, IT_PROFESSIONALISM, MATHEMATICS,
+                GENERAL_EDUCATION, UNRESTRICTED_ELECTIVES));
     }
 }


### PR DESCRIPTION
Resolves #169.

Currently, our application does not allow users to move the modules that
have been added to requirement categories.

This makes it difficult for users when they are moving the modules in
the requirement category around. They would have to delete and add the
modules multiple times during the moving process.

To address these issues, let's add the 'requirement_move' command to
allow users to move modules in the requirement category.

First, let's implement the logic to handle how the modules are going to
be moved from one requirement category to another.

* [1/3] [Logic: create logic for 'requirement_move' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/171/commits/a7de2dd3afdf5b1d2b00852cabba44ab2613bb7e)
* [2/3] [Logic: update application to take in new command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/171/commits/7778aacb6f6a85cda9a535c0d8c2e3261ea0f534)
* [3/3] [test/parser: creating test cases for new command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/171/commits/434f419b5915d6603246d99c55b122f67533d438)
