### PR TITLE
Model: implement `Comparable` interface

### DIFF
--- a/src/main/java/pwe/planner/model/module/Code.java
+++ b/src/main/java/pwe/planner/model/module/Code.java
@@ -7,7 +7,7 @@ import static pwe.planner.commons.util.AppUtil.checkArgument;
  * Represents a Module's code in the application.
  * Guarantees: immutable; is valid as declared in {@link #isValidCode(String)}
  */
-public class Code {
+public class Code implements Comparable<Code> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Codes should begin with two alphabets, followed by four digits, and may optionally end with an alphabet. "
@@ -59,4 +59,8 @@ public class Code {
         return value.hashCode();
     }
 
+    @Override
+    public int compareTo(Code other) {
+        return value.compareTo(other.value);
+    }
 }

--- a/src/main/java/pwe/planner/model/module/Module.java
+++ b/src/main/java/pwe/planner/model/module/Module.java
@@ -116,11 +116,11 @@ public class Module {
     public String toString() {
         final String allCorequisites = corequisites.isEmpty()
                 ? "None"
-                : corequisites.stream().map(Code::toString).collect(Collectors.joining(", "));
+                : corequisites.stream().sorted().map(Code::toString).collect(Collectors.joining(", "));
 
         final String allTags = tags.isEmpty()
                 ? "None"
-                : tags.stream().map(Tag::toString).collect(Collectors.joining(", "));
+                : tags.stream().sorted().map(Tag::toString).collect(Collectors.joining(", "));
 
         return String.format(STRING_REPRESENTATION, code, name, credits, allCorequisites, allTags);
     }

--- a/src/main/java/pwe/planner/model/planner/DegreePlanner.java
+++ b/src/main/java/pwe/planner/model/planner/DegreePlanner.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import pwe.planner.model.module.Code;
 
@@ -13,7 +14,11 @@ import pwe.planner.model.module.Code;
  * Represents a DegreePlanner in the degreePlanner list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class DegreePlanner {
+public class DegreePlanner implements Comparable<DegreePlanner> {
+    /**
+     * The format string representation of a {@link DegreePlanner} object used by {@link DegreePlanner#toString()}.
+     */
+    private static final String STRING_REPRESENTATION = "Year %1$s Semester %2$s: %3$s";
 
     // Identity fields
     private final Year year;
@@ -86,14 +91,19 @@ public class DegreePlanner {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append(" Year: ")
-                .append(getYear())
-                .append(" Semester: ")
-                .append(getSemester())
-                .append(" Codes: ")
-                .append(getCodes());
-        return builder.toString();
+        final String allCodes = codes.isEmpty()
+                ? "No modules"
+                : codes.stream().sorted().map(Code::toString).collect(Collectors.joining(", "));
+
+        return String.format(STRING_REPRESENTATION, year, semester, allCodes);
     }
 
+    @Override
+    public int compareTo(DegreePlanner other) {
+        int differenceInYear = year.compareTo(other.year);
+        if (differenceInYear == 0) {
+            return semester.compareTo(other.semester);
+        }
+        return differenceInYear;
+    }
 }

--- a/src/main/java/pwe/planner/model/planner/Semester.java
+++ b/src/main/java/pwe/planner/model/planner/Semester.java
@@ -7,7 +7,7 @@ import static pwe.planner.commons.util.AppUtil.checkArgument;
  * Represents a DegreePlanner's Semester in the degreePlanner list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Semester {
+public class Semester implements Comparable<Semester> {
 
     public static final String MESSAGE_SEMESTER_CONSTRAINTS =
             "Semester should only be either 1, 2, 3 or 4. Semester should not be blank";
@@ -56,5 +56,10 @@ public class Semester {
     @Override
     public int hashCode() {
         return plannerSemester.hashCode();
+    }
+
+    @Override
+    public int compareTo(Semester other) {
+        return plannerSemester.compareTo(other.plannerSemester);
     }
 }

--- a/src/main/java/pwe/planner/model/planner/Year.java
+++ b/src/main/java/pwe/planner/model/planner/Year.java
@@ -7,7 +7,7 @@ import static pwe.planner.commons.util.AppUtil.checkArgument;
  * Represents a DegreePlanner's Year in the degreePlanner list.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Year {
+public class Year implements Comparable<Year> {
 
     public static final String MESSAGE_YEAR_CONSTRAINTS =
             "Year should only be either 1, 2, 3 or 4. Year should not be blank";
@@ -56,5 +56,10 @@ public class Year {
     @Override
     public int hashCode() {
         return year.hashCode();
+    }
+
+    @Override
+    public int compareTo(Year other) {
+        return year.compareTo(other.year);
     }
 }

--- a/src/main/java/pwe/planner/model/tag/Tag.java
+++ b/src/main/java/pwe/planner/model/tag/Tag.java
@@ -7,7 +7,7 @@ import static pwe.planner.commons.util.AppUtil.checkArgument;
  * Represents a Tag in the application.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
-public class Tag {
+public class Tag implements Comparable<Tag> {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
@@ -54,4 +54,8 @@ public class Tag {
         return '[' + tagName + ']';
     }
 
+    @Override
+    public int compareTo(Tag other) {
+        return tagName.compareTo(other.tagName);
+    }
 }

--- a/src/main/java/pwe/planner/ui/DegreePlannerCard.java
+++ b/src/main/java/pwe/planner/ui/DegreePlannerCard.java
@@ -72,7 +72,7 @@ public class DegreePlannerCard extends UiPart<Region> {
             credits.getStyleClass().add("red");
         }
 
-        modulesInDegreePlanner.stream().sorted(Comparator.comparing(module -> module.getCode().toString()))
+        modulesInDegreePlanner.stream().sorted(Comparator.comparing(Module::getCode))
                 .forEach(module -> {
                     VBox vbox = new VBox();
                     VBox.setMargin(vbox, new Insets(1, 1, 1, 1));

--- a/src/main/java/pwe/planner/ui/ModuleCard.java
+++ b/src/main/java/pwe/planner/ui/ModuleCard.java
@@ -2,7 +2,6 @@ package pwe.planner.ui;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Comparator;
 import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
@@ -61,9 +60,7 @@ public class ModuleCard extends UiPart<Region> {
             corequisitesText = "None";
         }
         corequisites.setText("Co-requisites: " + corequisitesText);
-        module.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        module.getTags().stream().sorted().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
 
     @Override

--- a/src/main/java/pwe/planner/ui/RequirementCategoryCard.java
+++ b/src/main/java/pwe/planner/ui/RequirementCategoryCard.java
@@ -2,7 +2,6 @@ package pwe.planner.ui;
 
 import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Comparator;
 import java.util.stream.Stream;
 
 import javafx.collections.ObservableList;
@@ -71,7 +70,7 @@ public class RequirementCategoryCard extends UiPart<Region> {
             noCodes.getStyleClass().add("noModules");
             codes.getChildren().add(noCodes);
         } else {
-            requirementCategory.getCodeSet().stream().sorted(Comparator.comparing(code -> code.value))
+            requirementCategory.getCodeSet().stream().sorted()
                     .forEach(code -> codes.getChildren().add(new Label(code.value)));
         }
 


### PR DESCRIPTION
Very often, there is a need to compare/sort attributes of `Module` and
`DegreePlanner`. Yet, these attributes (such as `Code`, `Year`,
`Semester`) do not implement the `Comparable` interface to facilitate
sorting of data.

Let's update the attributes of `Module` and `DegreePlanner` to implement
the `Comparable` interface to simplify and standardise the way we
compare the values.