### PR TITLE
Logic: generalize `BooleanExperssionParser`

### DIFF
--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -5,7 +5,6 @@ import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
-import static pwe.planner.logic.parser.Operator.applyOperator;
 import static pwe.planner.logic.parser.Operator.getOperatorFromString;
 import static pwe.planner.logic.parser.ParserUtil.parseCode;
 import static pwe.planner.logic.parser.ParserUtil.parseCredits;
@@ -22,30 +21,37 @@ import pwe.planner.logic.parser.exceptions.ParseException;
 import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.KeywordsPredicate;
-import pwe.planner.model.module.Module;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
 
 /**
  * Parse input string into a composite predicate.
  */
-public class BooleanExpressionParser {
+public class BooleanExpressionParser<T> {
 
     private static final String WHITESPACE = " ";
+    private List<Prefix> prefixes;
+    private String stringToTokenize;
 
-    private static KeywordsPredicate getKeywordsPredicate(String args) throws ParseException {
+    public BooleanExpressionParser(String stringToTokenize, List<Prefix> prefixes) {
+        requireAllNonNull(stringToTokenize, prefixes);
+        this.stringToTokenize = stringToTokenize;
+        this.prefixes = prefixes;
+    }
+
+    private Predicate<T> getKeywordsPredicate(String args) throws ParseException {
         assert args != null;
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
-        KeywordsPredicate predicate = null;
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, prefixes.toArray(new Prefix[0]));
+        KeywordsPredicate<T> predicate = null;
+        if (prefixes.contains(PREFIX_NAME) && argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String nameKeyword = parseName(argMultimap.getValue(PREFIX_NAME).get()).toString();
-            predicate = new NameContainsKeywordsPredicate(List.of(nameKeyword));
-        } else if (argMultimap.getValue(PREFIX_CODE).isPresent()) {
+            predicate = new NameContainsKeywordsPredicate<T>(List.of(nameKeyword));
+        } else if (prefixes.contains(PREFIX_CODE) && argMultimap.getValue(PREFIX_CODE).isPresent()) {
             String codeKeyword = parseCode(argMultimap.getValue(PREFIX_CODE).get()).toString();
-            predicate = new CodeContainsKeywordsPredicate(List.of(codeKeyword));
-        } else if (argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
+            predicate = new CodeContainsKeywordsPredicate<T>(List.of(codeKeyword));
+        } else if (prefixes.contains(PREFIX_CREDITS) && argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
             String creditKeyword = parseCredits(argMultimap.getValue(PREFIX_CREDITS).get()).toString();
-            predicate = new CreditsContainsKeywordsPredicate(List.of(creditKeyword));
+            predicate = new CreditsContainsKeywordsPredicate<T>(List.of(creditKeyword));
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -53,19 +59,36 @@ public class BooleanExpressionParser {
     }
 
     /**
+     * Apply the operator on the 2 predicates
+     * @param operator
+     * @param predicate1
+     * @param predicate2
+     * @return a composite predicate
+     */
+    private Predicate<T> applyOperator(Operator operator, Predicate<T> predicate1,
+            Predicate<T> predicate2) throws ParseException {
+        requireAllNonNull(operator, predicate1, predicate2);
+
+        switch (operator) {
+        case OR:
+            return predicate1.or(predicate2);
+        case AND:
+            return predicate1.and(predicate2);
+        default:
+            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        }
+    }
+
+    /**
      * Parse input argument into a composite predicate.
      * This parse method make use of the shunting yard algorithm to convert in-fix to post fix then evaluate
      * the expression.
-     *
-     * @param stringToTokenize the user provided argument
      * @return a composite predicate
      */
-    public static Predicate<Module> parse(String stringToTokenize, List<Prefix> prefixes) throws ParseException {
-        requireAllNonNull(stringToTokenize, prefixes);
-
+    public Predicate<T> parse() throws ParseException {
         BooleanExpressionTokenizer tokenizer = new BooleanExpressionTokenizer(stringToTokenize, prefixes);
 
-        Deque<Predicate<Module>> output = new ArrayDeque<>();
+        Deque<Predicate<T>> output = new ArrayDeque<>();
         Deque<Operator> operatorStack = new ArrayDeque<>();
 
         try {
@@ -103,7 +126,7 @@ public class BooleanExpressionParser {
                     // as ArgumentMultimap require a whitespace before the args
                     // we will have to add a whitespace before our args without changing the code
                     // of ArgumentMultimap.
-                    Predicate<Module> in = getKeywordsPredicate(WHITESPACE + currentToken);
+                    Predicate<T> in = getKeywordsPredicate(WHITESPACE + currentToken);
                     output.push(in);
                     isNotExpectingLeftBracket = false;
                     break;

--- a/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
@@ -36,7 +36,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        Predicate<Module> predicate = BooleanExpressionParser.parse(args, PREFIXES);
+        BooleanExpressionParser<Module> expressionParser = new BooleanExpressionParser<>(args, PREFIXES);
+        Predicate<Module> predicate = expressionParser.parse();
         return new FindCommand(predicate);
     }
 

--- a/src/main/java/pwe/planner/logic/parser/Operator.java
+++ b/src/main/java/pwe/planner/logic/parser/Operator.java
@@ -6,11 +6,6 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_OR;
 
 import java.util.Map;
-import java.util.function.Predicate;
-
-import pwe.planner.logic.commands.FindCommand;
-import pwe.planner.logic.parser.exceptions.ParseException;
-import pwe.planner.model.module.Module;
 
 /**
  * Operators that can be used
@@ -56,29 +51,6 @@ public enum Operator {
      */
     public static boolean hasHigherPrecedence(Operator op1, Operator op2) {
         requireAllNonNull(op1, op2);
-
         return op1.precedence >= op2.precedence;
-    }
-
-    /**
-     * Apply the operator on the 2 predicate
-     *
-     * @param operator
-     * @param predicate1
-     * @param predicate2
-     * @return a composite predicate
-     */
-    public static Predicate<Module> applyOperator(Operator operator, Predicate<Module> predicate1,
-            Predicate<Module> predicate2) throws ParseException {
-        requireAllNonNull(operator, predicate1, predicate2);
-
-        switch (operator) {
-        case OR:
-            return predicate1.or(predicate2);
-        case AND:
-            return predicate1.and(predicate2);
-        default:
-            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
-        }
     }
 }

--- a/src/main/java/pwe/planner/model/module/CodeContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/CodeContainsKeywordsPredicate.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Tests that a {@code Module}'s {@code Code} matches any of the keywords given.
  */
-public class CodeContainsKeywordsPredicate implements KeywordsPredicate {
+public class CodeContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
     private final List<String> keywords;
 
     public CodeContainsKeywordsPredicate(List<String> keywords) {
@@ -18,12 +18,12 @@ public class CodeContainsKeywordsPredicate implements KeywordsPredicate {
     }
 
     @Override
-    public boolean test(Module module) {
-        requireNonNull(module);
+    public boolean test(T object) {
+        requireNonNull(object);
+        Module module = (Module) object;
 
         String moduleCode = module.getCode().toString();
-        return keywords.stream()
-                .anyMatch(keyword -> parseKeyword(keyword, moduleCode));
+        return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleCode));
     }
 
     @Override

--- a/src/main/java/pwe/planner/model/module/CreditsContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/CreditsContainsKeywordsPredicate.java
@@ -4,10 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
 
 import java.util.List;
+
 /**
  * Tests that a {@code Module}'s {@code Credit} matches any of the keywords given.
  */
-public class CreditsContainsKeywordsPredicate implements KeywordsPredicate {
+public class CreditsContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
     private final List<String> keywords;
 
     public CreditsContainsKeywordsPredicate(List<String> keywords) {
@@ -17,8 +18,9 @@ public class CreditsContainsKeywordsPredicate implements KeywordsPredicate {
     }
 
     @Override
-    public boolean test(Module module) {
-        requireNonNull(module);
+    public boolean test(T object) {
+        requireNonNull(object);
+        Module module = (Module) object;
 
         String moduleCredits = module.getCredits().toString();
         return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleCredits));

--- a/src/main/java/pwe/planner/model/module/KeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/KeywordsPredicate.java
@@ -7,5 +7,5 @@ import java.util.function.Predicate;
  * This interface let us have a list of predicate of different module's attributes
  */
 @FunctionalInterface
-public interface KeywordsPredicate extends Predicate<Module> {
+public interface KeywordsPredicate<T> extends Predicate<T> {
 }

--- a/src/main/java/pwe/planner/model/module/NameContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/NameContainsKeywordsPredicate.java
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Tests that a {@code Module}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements KeywordsPredicate {
+public class NameContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
     private final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
@@ -18,8 +18,9 @@ public class NameContainsKeywordsPredicate implements KeywordsPredicate {
     }
 
     @Override
-    public boolean test(Module module) {
-        requireNonNull(module);
+    public boolean test(T object) {
+        requireNonNull(object);
+        Module module = (Module) object;
 
         String moduleName = module.getName().toString();
         return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleName));


### PR DESCRIPTION
The `BooleanExpressionParser` was constrained to only `module` findings,
however, this does not allow us to extend the `BooleanExpression`
features to other component.

i.e. Allow the planner to do a filter based on boolean exprsesion.

Let's generalize the `BooleanExpressionparser` to allow different
`Predicate` based on the developer requirements and:
* cascade all changes to class that are affected