### PR TITLE
Logic: improve our `clear` command

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/ClearCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/ClearCommand.java
@@ -1,9 +1,11 @@
 package pwe.planner.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.model.util.InitialDataUtil.getInitialApplication;
 
 import pwe.planner.logic.CommandHistory;
+import pwe.planner.logic.commands.exceptions.CommandException;
 import pwe.planner.model.Application;
 import pwe.planner.model.Model;
 
@@ -16,12 +18,47 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Successfully cleared all data!\n"
             + "[Tip] If you unintentionally used this command, do use the undo command to revert back the changes!";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " [requirement or planner]\n"
+            + "requirement - clear all data related to requirement categories\n"
+            + "planner - clear all data related to degree planner";
+
+    public static final String PLANNER = "planner";
+    public static final String REQUIREMENT = "requirement";
+    private String panelToClear = "";
+
+    // default constructor
+    public ClearCommand() {
+    }
+
+    public ClearCommand(String panelToClear) {
+        requireNonNull(panelToClear);
+        this.panelToClear = panelToClear;
+    }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) {
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ClearCommand // instanceof handles nulls
+                && panelToClear.equals(((ClearCommand) other).panelToClear));
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
-        model.setApplication(getInitialApplication());
+        // initialize with default constructor
+        if (panelToClear.isEmpty()) {
+            model.setApplication(getInitialApplication());
+        } else {
+            if (panelToClear.equals(PLANNER)) {
+                model.resetPlanner();
+            } else if (panelToClear.equals(REQUIREMENT)) {
+                model.resetRequirement();
+            } else {
+                throw new CommandException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+            }
+        }
+
         model.commitApplication();
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/pwe/planner/logic/parser/ClearCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/ClearCommandParser.java
@@ -1,0 +1,41 @@
+package pwe.planner.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.logic.commands.ClearCommand.MESSAGE_USAGE;
+import static pwe.planner.logic.commands.ClearCommand.PLANNER;
+import static pwe.planner.logic.commands.ClearCommand.REQUIREMENT;
+
+import java.util.Set;
+
+import pwe.planner.commons.core.Messages;
+import pwe.planner.logic.commands.ClearCommand;
+import pwe.planner.logic.parser.exceptions.ParseException;
+import pwe.planner.model.Application;
+
+/**
+ * Parse the argument and clear the {@link Application} based on the arguments
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+    private Set<String> acceptedArgument = Set.of(PLANNER, REQUIREMENT);
+
+    /**
+     * Parse the user provided argument.
+     *
+     * @param args user provided argument
+     * @return {@link ClearCommand}
+     * @throws ParseException if no argument is provided
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        String trimmedLowerArgs = args.trim().toLowerCase();
+        if (trimmedLowerArgs.isEmpty()) {
+            return new ClearCommand();
+        }
+        if (acceptedArgument.contains(trimmedLowerArgs)) {
+            return new ClearCommand(trimmedLowerArgs);
+        } else {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/pwe/planner/logic/parser/CommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/CommandParser.java
@@ -70,7 +70,7 @@ public class CommandParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/pwe/planner/model/Application.java
+++ b/src/main/java/pwe/planner/model/Application.java
@@ -3,6 +3,7 @@ package pwe.planner.model;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -65,6 +66,29 @@ public class Application implements ReadOnlyApplication {
         setModules(newData.getModuleList());
         setDegreePlanners(newData.getDegreePlannerList());
         setRequirementCategories(newData.getRequirementCategoryList());
+    }
+
+    /**
+     * Resets the existing {@code DegreePlanner} data with empty {@code Code}.
+     */
+    public void resetPlanner() {
+        List<DegreePlanner> editedDegreePlannerList = new ArrayList<>();
+        for (DegreePlanner planner : degreePlanners) {
+            editedDegreePlannerList.add(new DegreePlanner(planner.getYear(), planner.getSemester(), Set.of()));
+        }
+        setDegreePlanners(editedDegreePlannerList);
+    }
+
+    /**
+     * Resets the existing {@code RequirementCategories} data with empty {@code Code}.
+     */
+    public void resetRequirement() {
+        List<RequirementCategory> editedRequirementCategories = new ArrayList<>();
+        for (RequirementCategory requirementCategory : requirementCategories) {
+            editedRequirementCategories.add(new RequirementCategory(requirementCategory.getName(),
+                    requirementCategory.getCredits(), Set.of()));
+        }
+        setRequirementCategories(editedRequirementCategories);
     }
 
     //// list overwrite operations

--- a/src/main/java/pwe/planner/model/Model.java
+++ b/src/main/java/pwe/planner/model/Model.java
@@ -84,6 +84,16 @@ public interface Model {
     void setApplication(ReadOnlyApplication application);
 
     /**
+     * Reset the Requirement Categories in {@code application}
+     */
+    void resetRequirement();
+
+    /**
+     * Reset the Degree Planner in {@code application}
+     */
+    void resetPlanner();
+
+    /**
      * Returns true if a module with the same identity as {@code module} exists in the application.
      */
     boolean hasModule(Module module);

--- a/src/main/java/pwe/planner/model/ModelManager.java
+++ b/src/main/java/pwe/planner/model/ModelManager.java
@@ -138,6 +138,16 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void resetRequirement() {
+        versionedApplication.resetRequirement();
+    }
+
+    @Override
+    public void resetPlanner() {
+        versionedApplication.resetPlanner();
+    }
+
+    @Override
     public ReadOnlyApplication getApplication() {
         return versionedApplication;
     }

--- a/src/main/java/pwe/planner/model/util/InitialDataUtil.java
+++ b/src/main/java/pwe/planner/model/util/InitialDataUtil.java
@@ -118,7 +118,7 @@ public class InitialDataUtil {
     );
     private static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategory(
             new Name("Information Security Requirements"),
-            new Credits("32"),
+            new Credits("20"),
             getCodeSet()
     );
 
@@ -154,7 +154,7 @@ public class InitialDataUtil {
 
     private static final RequirementCategory UNRESTRICTED_ELECTIVES = new RequirementCategory(
             new Name("Unrestricted Electives"),
-            new Credits("12"),
+            new Credits("32"),
             getCodeSet()
     );
 

--- a/src/test/java/pwe/planner/logic/commands/AddCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/AddCommandTest.java
@@ -163,6 +163,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void resetPlanner() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void resetRequirement() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasModule(Module module) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/pwe/planner/logic/commands/ClearCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/ClearCommandTest.java
@@ -26,7 +26,8 @@ public class ClearCommandTest {
         expectedModel.setApplication(getInitialApplication());
         expectedModel.commitApplication();
 
-        assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, commandHistory,
+                ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -40,7 +41,8 @@ public class ClearCommandTest {
         expectedModel.setApplication(getInitialApplication());
         expectedModel.commitApplication();
 
-        assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS,
+                expectedModel);
     }
 
 }

--- a/src/test/java/pwe/planner/logic/commands/ClearCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/ClearCommandTest.java
@@ -1,5 +1,7 @@
 package pwe.planner.logic.commands;
 
+import static pwe.planner.logic.commands.ClearCommand.PLANNER;
+import static pwe.planner.logic.commands.ClearCommand.REQUIREMENT;
 import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static pwe.planner.model.util.InitialDataUtil.getInitialApplication;
 import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
@@ -14,6 +16,9 @@ import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
 import pwe.planner.model.UserPrefs;
 import pwe.planner.storage.JsonSerializableApplication;
+import pwe.planner.testutil.TypicalDegreePlanners;
+import pwe.planner.testutil.TypicalModules;
+import pwe.planner.testutil.TypicalRequirementCategories;
 
 public class ClearCommandTest {
 
@@ -27,6 +32,34 @@ public class ClearCommandTest {
         expectedModel.commitApplication();
 
         assertCommandSuccess(new ClearCommand(), model, commandHistory,
+                ClearCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_clearRequirementCategoriesAndDegreePlanners() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        // only module is empty
+        TypicalDegreePlanners.getTypicalDegreePlanners().forEach(expectedModel::addDegreePlanner);
+        TypicalRequirementCategories.getTypicalRequirementCategories().forEach(
+                expectedModel::addRequirementCategory);
+        TypicalModules.getTypicalModules().forEach(expectedModel::addModule);
+        // actual model having all 3 sets of data
+        TypicalDegreePlanners.getTypicalDegreePlanners().forEach(model::addDegreePlanner);
+        TypicalRequirementCategories.getTypicalRequirementCategories().forEach(
+                model::addRequirementCategory);
+        TypicalModules.getTypicalModules().forEach(model::addModule);
+
+        expectedModel.resetRequirement();
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new ClearCommand(REQUIREMENT), model, commandHistory,
+                ClearCommand.MESSAGE_SUCCESS, expectedModel);
+
+        expectedModel.resetPlanner();
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new ClearCommand(PLANNER), model, commandHistory,
                 ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 

--- a/src/test/java/pwe/planner/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/ClearCommandParserTest.java
@@ -1,0 +1,57 @@
+package pwe.planner.logic.parser;
+
+import static pwe.planner.logic.commands.ClearCommand.MESSAGE_USAGE;
+import static pwe.planner.logic.commands.ClearCommand.PLANNER;
+import static pwe.planner.logic.commands.ClearCommand.REQUIREMENT;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import pwe.planner.commons.core.Messages;
+import pwe.planner.logic.commands.ClearCommand;
+
+public class ClearCommandParserTest {
+    private ClearCommandParser parser = new ClearCommandParser();
+
+    @Test
+    public void clear_success() {
+
+        // empty argument
+        assertParseSuccess(parser, "", new ClearCommand());
+        // multiple whitespaces
+        assertParseSuccess(parser, "                   ", new ClearCommand());
+
+        // clear command with valid argument
+        assertParseSuccess(parser, PLANNER, new ClearCommand(PLANNER));
+        assertParseSuccess(parser, REQUIREMENT, new ClearCommand(REQUIREMENT));
+
+        // clear command with case insensitive
+        assertParseSuccess(parser, "PLANNER", new ClearCommand(PLANNER));
+        assertParseSuccess(parser, "REQUIREMENT", new ClearCommand(REQUIREMENT));
+
+        // clear command with mixed cases
+        assertParseSuccess(parser, "PlAnNeR", new ClearCommand(PLANNER));
+        assertParseSuccess(parser, "ReQuIrEmEnt", new ClearCommand(REQUIREMENT));
+    }
+
+    @Test
+    public void clear_badArgument() {
+
+        // invalid argument
+        assertParseFailure(parser, "notExisting", String.format(
+                Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        // invalid argument with leading and trailing space.
+        assertParseFailure(parser, "            notExisting             ", String.format(
+                Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+        // substring of a valid argument -> false
+        assertParseFailure(parser, "planne", String.format(
+                Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "modul", String.format(
+                Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        assertParseFailure(parser, "requriemen", String.format(
+                Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+
+    }
+}

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -64,7 +64,7 @@ public class CommandParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " planner") instanceof ClearCommand);
     }
 
     @Test

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -1,11 +1,13 @@
 package systemtests;
 
 import static pwe.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static pwe.planner.logic.commands.ClearCommand.MESSAGE_USAGE;
 import static pwe.planner.model.util.InitialDataUtil.getInitialApplication;
 import static pwe.planner.testutil.TypicalModules.KEYWORD_MATCHING_MEIER;
 
 import org.junit.Test;
 
+import pwe.planner.commons.core.Messages;
 import pwe.planner.commons.core.index.Index;
 import pwe.planner.logic.commands.ClearCommand;
 import pwe.planner.logic.commands.RedoCommand;
@@ -20,14 +22,23 @@ public class ClearCommandSystemTest extends ApplicationSystemTest {
         final Model defaultModel = getModel();
 
         /* Case: clear non-empty application, command with leading spaces and trailing alphanumeric characters and
-         * spaces -> cleared
+         * spaces -> failed
          */
-        assertCommandSuccess("   " + ClearCommand.COMMAND_WORD + " ab12   ");
+        String command = ClearCommand.COMMAND_WORD + "      ab4";
+        String expectedResultMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE);
+        assertCommandFailure(command, expectedResultMessage);
+        assertSelectedCardUnchanged();
+
+
+        /*
+         * Case: clear command with trailing spaces -> passed
+         */
+        assertCommandSuccess(ClearCommand.COMMAND_WORD + "              ");
         assertSelectedCardUnchanged();
 
         /* Case: undo clearing application -> original application restored */
-        String command = UndoCommand.COMMAND_WORD;
-        String expectedResultMessage = UndoCommand.MESSAGE_SUCCESS;
+        command = UndoCommand.COMMAND_WORD;
+        expectedResultMessage = UndoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, expectedResultMessage, defaultModel);
         assertSelectedCardUnchanged();
 


### PR DESCRIPTION
The `clear` command will always clear all data in our storage, this may
not be optimal for our users. Given that we have 3 component, namely
`modules`, `requirements` and `degree planner`. The users may prefer to
clear individual component of the storage instead.

Let's improve our `clear` command and:
* clear a parser to handle the arguments
* fix unit tests which will fails after the new implementation.