### PR TITLE
Logic: implement `planner_show` command

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/PlannerShowCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/PlannerShowCommand.java
@@ -1,0 +1,74 @@
+package pwe.planner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_OR;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
+
+import java.util.function.Predicate;
+
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.model.Model;
+import pwe.planner.model.planner.DegreePlanner;
+
+/**
+ * Shows all semesters in degree plan that have year and semester contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class PlannerShowCommand extends Command {
+    public static final String COMMAND_WORD = "planner_show";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows all semesters which satisfies the expression of search conditions "
+            + "specified based on year and/or semester in the degree plan\n"
+            + "Format: " + COMMAND_WORD
+            + " [" + PREFIX_YEAR + "YEAR] "
+            + "OPERATOR "
+            + "[" + PREFIX_SEMESTER + "SEMESTER]\n"
+            + "OPERATOR " + OPERATOR_AND
+            + " for logical \"AND\" operation (both conditions A AND B must match)\n"
+            + "OPERATOR " + OPERATOR_OR
+            + " for logical \"OR\" operation (either conditions A OR B must match)\n"
+            + "[Tip] You can also use parenthesis to group which search conditions to be evaluated first.\n"
+            + "Example 1: " + COMMAND_WORD + " " + PREFIX_YEAR + "1 " + OPERATOR_AND + " "
+            + PREFIX_SEMESTER + "2\n"
+            + "Example 2: " + COMMAND_WORD + " " + PREFIX_YEAR + "1 " + OPERATOR_OR + " " + PREFIX_YEAR + "2\n"
+            + "Example 3: " + COMMAND_WORD + " " + PREFIX_YEAR + "1 " + OPERATOR_AND + " "
+            + OPERATOR_LEFT_BRACKET + " " + PREFIX_SEMESTER + "1 " + OPERATOR_OR + " " + PREFIX_SEMESTER + "2 "
+            + OPERATOR_RIGHT_BRACKET + " ";
+
+    public static final String MESSAGE_SUCCESS = "Number of semesters showed: %1$s";
+
+    private final Predicate<DegreePlanner> predicate;
+
+    public PlannerShowCommand(Predicate<DegreePlanner> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+
+        model.updateFilteredDegreePlannerList(predicate);
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, model.getFilteredDegreePlannerList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PlannerShowCommand)) {
+            return false;
+        }
+
+        PlannerShowCommand otherCommand = (PlannerShowCommand) other;
+        return predicate.equals(otherCommand.predicate);
+    }
+}

--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -4,10 +4,14 @@ import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
 import static pwe.planner.logic.parser.Operator.getOperatorFromString;
 import static pwe.planner.logic.parser.ParserUtil.parseCode;
 import static pwe.planner.logic.parser.ParserUtil.parseCredits;
 import static pwe.planner.logic.parser.ParserUtil.parseName;
+import static pwe.planner.logic.parser.ParserUtil.parseSemester;
+import static pwe.planner.logic.parser.ParserUtil.parseYear;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -22,6 +26,8 @@ import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.KeywordsPredicate;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
+import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
+import pwe.planner.model.planner.YearContainsKeywordPredicate;
 
 /**
  * Parse input string into a composite predicate.
@@ -35,7 +41,8 @@ public class BooleanExpressionParser<T> {
     public static final String MESSAGE_INVALID_OPERATOR = "This operator is not supported yet!";
     public static final String MESSAGE_INVALID_OPERATOR_APPLICATION =
             "Perhaps you missed out one or more search terms?\n" + MESSAGE_TIP;
-    public static final String MESSAGE_UNABLE_TO_CREATE_PREDICATE = "No valid prefixes found";
+    public static final String MESSAGE_UNABLE_TO_CREATE_PREDICATE =
+            "%1$s is not a valid parameter accepted by this command!";
     public static final String MESSAGE_EMPTY_OUTPUT = "There seems to be an empty condition!\n"
             + "Perhaps you might want to consider providing the criteria to filter?\n" + MESSAGE_TIP;
     public static final String MESSAGE_GENERAL_FAIL = "You might want to double check your filter expression!\n"
@@ -67,8 +74,14 @@ public class BooleanExpressionParser<T> {
         } else if (prefixes.contains(PREFIX_CREDITS) && argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
             String creditKeyword = parseCredits(argMultimap.getValue(PREFIX_CREDITS).get()).toString();
             predicate = new CreditsContainsKeywordsPredicate<T>(List.of(creditKeyword));
+        } else if (prefixes.contains(PREFIX_YEAR) && argMultimap.getValue(PREFIX_YEAR).isPresent()) {
+            String yearKeyword = parseYear(argMultimap.getValue(PREFIX_YEAR).get()).toString();
+            predicate = new YearContainsKeywordPredicate<>(yearKeyword);
+        } else if (prefixes.contains(PREFIX_SEMESTER) && argMultimap.getValue(PREFIX_SEMESTER).isPresent()) {
+            String semesterKeyword = parseSemester(argMultimap.getValue(PREFIX_SEMESTER).get()).toString();
+            predicate = new SemesterContainsKeywordPredicate<>(semesterKeyword);
         } else {
-            throw new BooleanParserPredicateException(MESSAGE_UNABLE_TO_CREATE_PREDICATE);
+            throw new BooleanParserPredicateException(String.format(MESSAGE_UNABLE_TO_CREATE_PREDICATE, args));
         }
         return predicate;
     }

--- a/src/main/java/pwe/planner/logic/parser/CommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/CommandParser.java
@@ -20,6 +20,7 @@ import pwe.planner.logic.commands.ListCommand;
 import pwe.planner.logic.commands.PlannerAddCommand;
 import pwe.planner.logic.commands.PlannerListCommand;
 import pwe.planner.logic.commands.PlannerMoveCommand;
+import pwe.planner.logic.commands.PlannerShowCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
@@ -92,6 +93,9 @@ public class CommandParser {
 
         case PlannerListCommand.COMMAND_WORD:
             return new PlannerListCommand();
+
+        case PlannerShowCommand.COMMAND_WORD:
+            return new PlannerShowCommandParser().parse(arguments);
 
         case PlannerMoveCommand.COMMAND_WORD:
             return new PlannerMoveCommandParser().parse(arguments);

--- a/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package pwe.planner.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static pwe.planner.commons.core.LogsCenter.getLogger;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.logic.commands.FindCommand.MESSAGE_USAGE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
@@ -9,6 +10,7 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 
 import pwe.planner.logic.commands.FindCommand;
 import pwe.planner.logic.parser.exceptions.BooleanParserException;
@@ -20,6 +22,7 @@ import pwe.planner.model.module.Module;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    private static final Logger logger = getLogger(FindCommandParser.class);
     private static final List<Prefix> PREFIXES = List.of(
             PREFIX_NAME,
             PREFIX_CODE,
@@ -44,6 +47,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             Predicate<Module> predicate = expressionParser.parse();
             return new FindCommand(predicate);
         } catch (BooleanParserPredicateException predicateException) {
+            logger.warning(predicateException.getMessage());
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         } catch (BooleanParserException parserException) {
             throw new ParseException(parserException.getMessage());

--- a/src/main/java/pwe/planner/logic/parser/PlannerShowCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/PlannerShowCommandParser.java
@@ -1,0 +1,57 @@
+package pwe.planner.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.commons.core.LogsCenter.getLogger;
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import pwe.planner.logic.commands.PlannerShowCommand;
+import pwe.planner.logic.parser.exceptions.BooleanParserException;
+import pwe.planner.logic.parser.exceptions.BooleanParserPredicateException;
+import pwe.planner.logic.parser.exceptions.ParseException;
+import pwe.planner.model.planner.DegreePlanner;
+
+/**
+ * Parses input arguments and creates a new PlannerShowCommand object
+ */
+public class PlannerShowCommandParser implements Parser<PlannerShowCommand> {
+    private static final Logger logger = getLogger(PlannerShowCommandParser.class);
+    private static final List<Prefix> PREFIXES = List.of(
+            PREFIX_YEAR,
+            PREFIX_SEMESTER
+    );
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PlannerShowCommand
+     * and returns an PlannerShowCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PlannerShowCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
+            throw new ParseException(PlannerShowCommand.MESSAGE_USAGE);
+        }
+
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerShowCommand.MESSAGE_USAGE));
+        }
+        try {
+            BooleanExpressionParser<DegreePlanner> expressionParser = new BooleanExpressionParser<>(args, PREFIXES);
+            Predicate<DegreePlanner> predicate = expressionParser.parse();
+            return new PlannerShowCommand(predicate);
+        } catch (BooleanParserPredicateException predicateException) {
+            logger.warning(predicateException.getMessage());
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerShowCommand.MESSAGE_USAGE));
+        } catch (BooleanParserException parserException) {
+            throw new ParseException(parserException.getMessage());
+        }
+    }
+}

--- a/src/main/java/pwe/planner/model/planner/SemesterContainsKeywordPredicate.java
+++ b/src/main/java/pwe/planner/model/planner/SemesterContainsKeywordPredicate.java
@@ -1,0 +1,35 @@
+package pwe.planner.model.planner;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
+
+import pwe.planner.model.module.KeywordsPredicate;
+
+/**
+ * Tests that a {@code DegreePlanner}'s {@code Semester} matches any of the keyword given.
+ */
+public class SemesterContainsKeywordPredicate<T> implements KeywordsPredicate<T> {
+    private final String keyword;
+
+    public SemesterContainsKeywordPredicate(String keyword) {
+        requireNonNull(keyword);
+
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(T object) {
+        requireNonNull(object);
+        DegreePlanner degreePlanner = (DegreePlanner) object;
+
+        String semester = degreePlanner.getSemester().toString();
+        return parseKeyword(keyword, semester);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SemesterContainsKeywordPredicate // instanceof handles nulls
+                && keyword.equals(((SemesterContainsKeywordPredicate) other).keyword)); // state check
+    }
+}

--- a/src/main/java/pwe/planner/model/planner/YearContainsKeywordPredicate.java
+++ b/src/main/java/pwe/planner/model/planner/YearContainsKeywordPredicate.java
@@ -1,0 +1,35 @@
+package pwe.planner.model.planner;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
+
+import pwe.planner.model.module.KeywordsPredicate;
+
+/**
+ * Tests that a {@code DegreePlanner}'s {@code Year} matches any of the keywords given.
+ */
+public class YearContainsKeywordPredicate<T> implements KeywordsPredicate<T> {
+    private final String keyword;
+
+    public YearContainsKeywordPredicate(String keyword) {
+        requireNonNull(keyword);
+
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(T object) {
+        requireNonNull(object);
+        DegreePlanner degreePlanner = (DegreePlanner) object;
+
+        String year = degreePlanner.getYear().toString();
+        return parseKeyword(keyword, year);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof YearContainsKeywordPredicate // instanceof handles nulls
+                && keyword.equals(((YearContainsKeywordPredicate) other).keyword)); // state check
+    }
+}

--- a/src/test/java/pwe/planner/logic/commands/PlannerShowCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/PlannerShowCommandTest.java
@@ -1,0 +1,98 @@
+package pwe.planner.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_1;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_2;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_2_SEMESTER_1;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_3_SEMESTER_1;
+import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
+import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.model.Model;
+import pwe.planner.model.ModelManager;
+import pwe.planner.model.UserPrefs;
+import pwe.planner.model.planner.DegreePlanner;
+import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
+import pwe.planner.model.planner.YearContainsKeywordPredicate;
+import pwe.planner.storage.JsonSerializableApplication;
+
+public class PlannerShowCommandTest {
+    private Model model = new ModelManager(
+            new JsonSerializableApplication(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                    getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+    private Model expectedModel = new ModelManager(
+            new JsonSerializableApplication(getTypicalModuleList(), getTypicalDegreePlannerList(),
+                    getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    public PlannerShowCommandTest() throws IllegalValueException {}
+
+    @Test
+    public void execute_validYear_success() {
+        YearContainsKeywordPredicate<DegreePlanner> predicate = prepareYearPredicate("1");
+        PlannerShowCommand command = new PlannerShowCommand(predicate);
+        expectedModel.updateFilteredDegreePlannerList(predicate);
+        String expectedMessage =
+                String.format(PlannerShowCommand.MESSAGE_SUCCESS, expectedModel.getFilteredDegreePlannerList().size());
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_2), model.getFilteredDegreePlannerList());
+    }
+
+    @Test
+    public void execute_validSemester_success() {
+        SemesterContainsKeywordPredicate<DegreePlanner> predicate = prepareSemesterPredicate("1");
+        PlannerShowCommand command = new PlannerShowCommand(predicate);
+        expectedModel.updateFilteredDegreePlannerList(predicate);
+        String expectedMessage =
+                String.format(PlannerShowCommand.MESSAGE_SUCCESS, expectedModel.getFilteredDegreePlannerList().size());
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(YEAR_1_SEMESTER_1, YEAR_2_SEMESTER_1, YEAR_3_SEMESTER_1),
+                model.getFilteredDegreePlannerList());
+    }
+
+    @Test
+    public void equals() {
+        YearContainsKeywordPredicate<DegreePlanner> firstPredicate = prepareYearPredicate("1");
+        SemesterContainsKeywordPredicate<DegreePlanner> secondPredicate = prepareSemesterPredicate("1");
+
+        PlannerShowCommand plannerShowFirstCommand = new PlannerShowCommand(firstPredicate);
+        PlannerShowCommand plannerShowSecondCommand = new PlannerShowCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(plannerShowFirstCommand.equals(plannerShowFirstCommand));
+
+        // same values -> returns true
+        PlannerShowCommand plannerShowFirstCommandCopy = new PlannerShowCommand(firstPredicate);
+        assertTrue(plannerShowFirstCommand.equals(plannerShowFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(plannerShowFirstCommand.equals(1));
+
+        // different module -> returns false
+        assertFalse(plannerShowFirstCommand.equals(plannerShowSecondCommand));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code YearContainsKeywordPredicate}.
+     */
+    private YearContainsKeywordPredicate<DegreePlanner> prepareYearPredicate(String userInput) {
+        return new YearContainsKeywordPredicate<>(userInput);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code SemesterContainsKeywordPredicate}.
+     */
+    private SemesterContainsKeywordPredicate<DegreePlanner> prepareSemesterPredicate(String userInput) {
+        return new SemesterContainsKeywordPredicate<>(userInput);
+    }
+}

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -31,6 +31,7 @@ import pwe.planner.logic.commands.HistoryCommand;
 import pwe.planner.logic.commands.ListCommand;
 import pwe.planner.logic.commands.PlannerListCommand;
 import pwe.planner.logic.commands.PlannerMoveCommand;
+import pwe.planner.logic.commands.PlannerShowCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
@@ -44,6 +45,7 @@ import pwe.planner.model.module.Name;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
 import pwe.planner.model.planner.Semester;
 import pwe.planner.model.planner.Year;
+import pwe.planner.model.planner.YearContainsKeywordPredicate;
 import pwe.planner.testutil.EditModuleDescriptorBuilder;
 import pwe.planner.testutil.ModuleBuilder;
 import pwe.planner.testutil.ModuleUtil;
@@ -134,6 +136,14 @@ public class CommandParserTest {
     public void parseCommand_plannerList() throws Exception {
         assertTrue(parser.parseCommand(PlannerListCommand.COMMAND_WORD) instanceof PlannerListCommand);
         assertTrue(parser.parseCommand(PlannerListCommand.COMMAND_WORD + " 3") instanceof PlannerListCommand);
+    }
+
+    @Test
+    public void parseCommand_plannerShow() throws Exception {
+        String keyword = "1";
+        PlannerShowCommand yearCommand = (PlannerShowCommand) parser.parseCommand(PlannerShowCommand.COMMAND_WORD + " "
+                + PREFIX_YEAR + "1");
+        assertEquals(new PlannerShowCommand(new YearContainsKeywordPredicate<>(keyword)), yearCommand);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/PlannerShowCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/PlannerShowCommandParserTest.java
@@ -1,0 +1,129 @@
+package pwe.planner.logic.parser;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_OR;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import pwe.planner.logic.commands.PlannerShowCommand;
+import pwe.planner.logic.parser.exceptions.ParseException;
+import pwe.planner.model.planner.Semester;
+import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
+import pwe.planner.model.planner.Year;
+import pwe.planner.model.planner.YearContainsKeywordPredicate;
+
+public class PlannerShowCommandParserTest {
+    private static final String WHITESPACE = " ";
+    private PlannerShowCommandParser parser = new PlannerShowCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        //Displays usage
+        assertParseFailure(parser, "", PlannerShowCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PlannerShowCommand.MESSAGE_USAGE));
+        // No year argument -> assertFailure
+        assertParseFailure(parser, PREFIX_YEAR + "     ", Year.MESSAGE_YEAR_CONSTRAINTS);
+        // No semester argument -> assertFailure
+        assertParseFailure(parser, PREFIX_SEMESTER + "     ", Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validArgs_returnsPlannerShowCommand() {
+        PlannerShowCommand expectedPlannerShowYearCommand =
+                new PlannerShowCommand(new YearContainsKeywordPredicate<>("1"));
+        // single year
+        assertParseSuccess(parser, PREFIX_YEAR + "1", expectedPlannerShowYearCommand);
+
+        PlannerShowCommand expectedPlannerShowSemesterCommand =
+                new PlannerShowCommand(new SemesterContainsKeywordPredicate<>("1"));
+        // single semester
+        assertParseSuccess(parser, PREFIX_SEMESTER + "1", expectedPlannerShowSemesterCommand);
+    }
+
+    @Test
+    public void parse_validArgs() {
+        // test for boolean OR
+        // year/1 || year/2
+        assertParserSuccess(parser, PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_OR + WHITESPACE
+                + PREFIX_YEAR + "2");
+        // sem/1 || sem/2
+        assertParserSuccess(parser, PREFIX_SEMESTER + "1" + WHITESPACE + OPERATOR_OR + WHITESPACE
+                + PREFIX_SEMESTER + "2");
+
+        // test for boolean AND
+        // year/1 && year/1
+        assertParserSuccess(parser, PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_AND + WHITESPACE
+                + PREFIX_YEAR + "1");
+        // sem/1 && sem/1
+        assertParserSuccess(parser, PREFIX_SEMESTER + "1" + WHITESPACE + OPERATOR_AND + WHITESPACE
+                + PREFIX_SEMESTER + "1");
+        // year/1 && sem/2
+        assertParserSuccess(parser, PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_AND + WHITESPACE
+                + PREFIX_SEMESTER + "2");
+
+        // test for boolean AND OR with LEFT_BRACKET RIGHT_BRACKET
+        // year/1 && ( sem/1 || sem/2 )
+        assertParserSuccess(parser, PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_AND + WHITESPACE
+                + OPERATOR_LEFT_BRACKET + WHITESPACE + PREFIX_SEMESTER + "1" + WHITESPACE + OPERATOR_OR
+                + WHITESPACE + PREFIX_SEMESTER + "2" + WHITESPACE + OPERATOR_RIGHT_BRACKET);
+    }
+
+    @Test
+    public void parseInvalidArgs() {
+        assertParseThrowsException(parser, "invalid/DoesNotExists");
+        // year/1 sem/2
+        assertParseThrowsException(parser, PREFIX_YEAR + "1" + WHITESPACE + PREFIX_SEMESTER + "2");
+        // ()
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET);
+        // ()()
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET + OPERATOR_LEFT_BRACKET
+                + OPERATOR_RIGHT_BRACKET);
+        // ())
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET + OPERATOR_RIGHT_BRACKET);
+        // year/1 ) sem/2
+        assertParseThrowsException(parser,
+                PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_RIGHT_BRACKET + PREFIX_SEMESTER + "2");
+        // (year/1 || sem/2
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_OR
+                + PREFIX_SEMESTER + "2");
+        // year/1 && (sem/1 || sem/2))
+        assertParseThrowsException(parser, PREFIX_YEAR + "1" + WHITESPACE + OPERATOR_AND + OPERATOR_LEFT_BRACKET
+                + PREFIX_SEMESTER + "1" + WHITESPACE + OPERATOR_OR + PREFIX_SEMESTER + "2" + OPERATOR_RIGHT_BRACKET
+                + OPERATOR_RIGHT_BRACKET);
+    }
+
+    /**
+     * Assert if a parse is successful.
+     * Checks if a parser return a PlannerShowCommand.
+     */
+    private void assertParserSuccess(PlannerShowCommandParser parser, String input) {
+        try {
+            PlannerShowCommand command = parser.parse(input);
+            assertNotNull("Expecting not null", command);
+        } catch (ParseException e) {
+            fail("Expecting no parser error");
+        }
+    }
+
+    /**
+     * Assert if a parse return an exception.
+     */
+    private void assertParseThrowsException(PlannerShowCommandParser parser, String str) {
+        try {
+            parser.parse(str);
+            fail("Expected a parse error");
+        } catch (ParseException ignore) {
+            // we want the exception to be thrown.
+        }
+    }
+}

--- a/src/test/java/pwe/planner/model/planner/SemesterContainsKeywordPredicateTest.java
+++ b/src/test/java/pwe/planner/model/planner/SemesterContainsKeywordPredicateTest.java
@@ -1,0 +1,51 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import pwe.planner.testutil.DegreePlannerBuilder;
+
+public class SemesterContainsKeywordPredicateTest {
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "1";
+        String secondPredicateKeyword = "2";
+
+        SemesterContainsKeywordPredicate<DegreePlanner> firstPredicate =
+                new SemesterContainsKeywordPredicate<>(firstPredicateKeyword);
+        SemesterContainsKeywordPredicate<DegreePlanner> secondPredicate =
+                new SemesterContainsKeywordPredicate<>(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        SemesterContainsKeywordPredicate<DegreePlanner> firstPredicateCopy =
+                new SemesterContainsKeywordPredicate<>(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // different module -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_semesterContainsKeywords_returnsTrue() {
+        // One keyword
+        SemesterContainsKeywordPredicate<DegreePlanner> predicate =
+                new SemesterContainsKeywordPredicate<>("1");
+        assertTrue(predicate.test(new DegreePlannerBuilder().withSemester("1").build()));
+
+    }
+
+    @Test
+    public void test_semesterDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        SemesterContainsKeywordPredicate<DegreePlanner> predicate = new SemesterContainsKeywordPredicate<>("4");
+        assertFalse(predicate.test(new DegreePlannerBuilder().withSemester("1").build()));
+    }
+}

--- a/src/test/java/pwe/planner/model/planner/YearContainsKeywordPredicateTest.java
+++ b/src/test/java/pwe/planner/model/planner/YearContainsKeywordPredicateTest.java
@@ -1,0 +1,50 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import pwe.planner.testutil.DegreePlannerBuilder;
+
+public class YearContainsKeywordPredicateTest {
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "1";
+        String secondPredicateKeyword = "2";
+
+        YearContainsKeywordPredicate<DegreePlanner> firstPredicate =
+                new YearContainsKeywordPredicate<>(firstPredicateKeyword);
+        YearContainsKeywordPredicate<DegreePlanner> secondPredicate =
+                new YearContainsKeywordPredicate<>(secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        YearContainsKeywordPredicate<DegreePlanner> firstPredicateCopy =
+                new YearContainsKeywordPredicate<>(firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // different module -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_yearContainsKeywords_returnsTrue() {
+        // One keyword
+        YearContainsKeywordPredicate<DegreePlanner> predicate =
+                new YearContainsKeywordPredicate<>("1");
+        assertTrue(predicate.test(new DegreePlannerBuilder().withYear("1").build()));
+    }
+
+    @Test
+    public void test_yearDoesNotContainKeywords_returnsFalse() {
+        // Non-matching keyword
+        YearContainsKeywordPredicate<DegreePlanner> predicate = new YearContainsKeywordPredicate<>("4");
+        assertFalse(predicate.test(new DegreePlannerBuilder().withYear("1").build()));
+    }
+}

--- a/src/test/java/pwe/planner/testutil/TypicalDegreePlanners.java
+++ b/src/test/java/pwe/planner/testutil/TypicalDegreePlanners.java
@@ -13,19 +13,36 @@ import pwe.planner.model.planner.DegreePlanner;
  */
 public class TypicalDegreePlanners {
 
-    private static final DegreePlanner YEAR_1_SEMESTER_1 =
-            new DegreePlannerBuilder().withYear("1").withSemester("1")
-                    .withCodes("CS1231", "CS2100", "CS1010", "CS2040C", "CS2102").build();
-    private static final DegreePlanner YEAR_1_SEMESTER_2 =
-            new DegreePlannerBuilder().withYear("1").withSemester("2").build();
-    private static final DegreePlanner YEAR_2_SEMESTER_1 =
-            new DegreePlannerBuilder().withYear("2").withSemester("1").build();
-    private static final DegreePlanner YEAR_2_SEMESTER_2 =
-            new DegreePlannerBuilder().withYear("2").withSemester("2").build();
-    private static final DegreePlanner YEAR_3_SEMESTER_1 =
-            new DegreePlannerBuilder().withYear("3").withSemester("1").build();
-    private static final DegreePlanner YEAR_3_SEMESTER_2 =
-            new DegreePlannerBuilder().withYear("3").withSemester("2").build();
+    public static final DegreePlanner YEAR_1_SEMESTER_1 = new DegreePlannerBuilder()
+            .withYear("1")
+            .withSemester("1")
+            .withCodes("CS1231", "CS2100", "CS1010", "CS2040C", "CS2102")
+            .build();
+
+    public static final DegreePlanner YEAR_1_SEMESTER_2 = new DegreePlannerBuilder()
+            .withYear("1")
+            .withSemester("2")
+            .build();
+
+    public static final DegreePlanner YEAR_2_SEMESTER_1 = new DegreePlannerBuilder()
+            .withYear("2")
+            .withSemester("1")
+            .build();
+
+    public static final DegreePlanner YEAR_2_SEMESTER_2 = new DegreePlannerBuilder()
+            .withYear("2")
+            .withSemester("2")
+            .build();
+
+    public static final DegreePlanner YEAR_3_SEMESTER_1 = new DegreePlannerBuilder()
+            .withYear("3")
+            .withSemester("1")
+            .build();
+
+    public static final DegreePlanner YEAR_3_SEMESTER_2 = new DegreePlannerBuilder()
+            .withYear("3")
+            .withSemester("2")
+            .build();
 
     /**
      * Returns an {@code Application} with all the typical degree planners.


### PR DESCRIPTION
Resolves #96 

Currently, the application does not have the `planner_show` command that allow the user to see specific academic semesters that he/she wants.

Let's carry out the followings to allow the implementation of `planner_show`:
* [1/5] [Model: add predicate classes to test 'Year' and 'Semester'](https://github.com/CS2113-AY1819S2-T09-1/main/pull/196/commits/ecbb5c10f1dbe3192bed57bdb2dc933dc4ecaba6)
* [2/5] [Logic: add 'planner_show' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/196/commits/52a0dda2869144c7307c83c497854f9dcd34a734)
* [3/5] [Test: add tests for 'Year' and 'Semester' predicates class](https://github.com/CS2113-AY1819S2-T09-1/main/pull/196/commits/700e621c808dec0bb55eab5fc36913465e368a59)
* [4/5] [TestUtil: update to allow using variables in other classes](https://github.com/CS2113-AY1819S2-T09-1/main/pull/196/commits/00b0d09dd2437b8d1b1f819c271a77dbcd79fb4d)
* [5/5] [Test: add test cases for 'planner_show'](https://github.com/CS2113-AY1819S2-T09-1/main/pull/196/commits/4f9a800ea2598d5bd79641a1c781c83c1e0a9a49)

Note: As we have discussed, in order to reduce the confusion, we will be changing the command name from `planner_list` to `planner_show`.