### PR TITLE
Logic: update `planner_move` to handle co-requisites

### DIFF
--- a/src/main/java/pwe/planner/logic/parser/PlannerMoveCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/PlannerMoveCommandParser.java
@@ -29,6 +29,10 @@ public class PlannerMoveCommandParser implements Parser<PlannerMoveCommand> {
     public PlannerMoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
+        if (args.isEmpty()) {
+            throw new ParseException(PlannerMoveCommand.MESSAGE_USAGE);
+        }
+
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_YEAR, PREFIX_SEMESTER, PREFIX_CODE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_YEAR, PREFIX_SEMESTER, PREFIX_CODE)

--- a/src/main/java/pwe/planner/model/Model.java
+++ b/src/main/java/pwe/planner/model/Model.java
@@ -219,6 +219,13 @@ public interface Model {
      */
     void setDegreePlanner(DegreePlanner target, DegreePlanner editedDegreePlanner);
 
+    /**
+     * Moves the given module code {@code code} from {@code sourcePlanner} to {@code destinationPlanner} along
+     * with its corequisites.
+     * {@code code} must exist in the {@code sourcePlanner}.
+     */
+    void moveModuleBetweenPlanner(DegreePlanner sourcePlanner, DegreePlanner destinationPlanner, Code code);
+
     /** Returns an unmodifiable view of the filtered degreePlanner list */
     ObservableList<DegreePlanner> getFilteredDegreePlannerList();
 

--- a/src/main/java/pwe/planner/model/ModelManager.java
+++ b/src/main/java/pwe/planner/model/ModelManager.java
@@ -351,6 +351,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void moveModuleBetweenPlanner(DegreePlanner sourcePlanner, DegreePlanner destinationPlanner, Code code) {
+        requireAllNonNull(sourcePlanner, destinationPlanner, code);
+
+        versionedApplication.moveModuleBetweenPlanner(sourcePlanner, destinationPlanner, code);
+    }
+
+    @Override
     public ObservableList<DegreePlanner> getFilteredDegreePlannerList() {
         return filteredDegreePlanners;
     }
@@ -394,8 +401,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setRequirementCategory(RequirementCategory target,
-            RequirementCategory editedRequirementCategory) {
+    public void setRequirementCategory(RequirementCategory target, RequirementCategory editedRequirementCategory) {
         requireAllNonNull(target, editedRequirementCategory);
 
         versionedApplication.setRequirementCategory(target, editedRequirementCategory);

--- a/src/test/data/JsonSerializableApplicationTest/typicalModulesList.json
+++ b/src/test/data/JsonSerializableApplicationTest/typicalModulesList.json
@@ -39,7 +39,7 @@
     "code" : "CS2102",
     "name" : "Fiona Kunz",
     "credits" : "5",
-    "semesters" : [ "1", "2" ],
+    "semesters" : [ "1" ],
     "corequisites": [ "CS1231" ],
     "tagged" : [ ]
   }, {

--- a/src/test/java/pwe/planner/logic/commands/AddCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/AddCommandTest.java
@@ -274,7 +274,12 @@ public class AddCommandTest {
 
         @Override
         public void setDegreePlanner(DegreePlanner target, DegreePlanner editedDegreePlanner) {
-            //ToDo: implement error check
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void moveModuleBetweenPlanner(DegreePlanner sourcePlanner, DegreePlanner destinationPlanner, Code code) {
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override

--- a/src/test/java/pwe/planner/logic/parser/PlannerMoveCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/PlannerMoveCommandParserTest.java
@@ -20,6 +20,12 @@ public class PlannerMoveCommandParserTest {
     private PlannerMoveCommandParser parser = new PlannerMoveCommandParser();
 
     @Test
+    public void parse_emptyArg_throwsParseException() {
+        //Displays usage
+        assertParseFailure(parser, "", PlannerMoveCommand.MESSAGE_USAGE);
+    }
+
+    @Test
     public void parse_invalidValue_failure() {
         // invalid code
         assertParseFailure(parser, " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "1 "

--- a/src/test/java/pwe/planner/testutil/TypicalModules.java
+++ b/src/test/java/pwe/planner/testutil/TypicalModules.java
@@ -70,7 +70,7 @@ public class TypicalModules {
             .withCode("CS2102")
             .withName("Fiona Kunz")
             .withCredits("5")
-            .withSemesters("1", "2")
+            .withSemesters("1")
             .withCorequisites("CS1231")
             .build();
 


### PR DESCRIPTION
Resolves #164. 

The application allows the user to set co-requisites to modules. However, `planner_move` does not handle co-requisites. Hence, the user has to move the codes that shares co-requisites manually.

Let's enhance `planner_move` command by allowing it to handle co-requisites so that when a module is moved, its co-requisites are moved along if they exist in the degree plan.

In addition, since there has been update on `ModuleList` to store the semesters the module is offered in, let's also enhance `planner_move` command to check if the module is offered in the semester the user wants to move to.

The followings are the changes in the process of the enhancement:
* [1/3] [Logic: update 'planner_move' to handle co-requisites](https://github.com/CS2113-AY1819S2-T09-1/main/pull/197/commits/1bc4468057d89578f5e5b58a207ad25b40a0b020)
* [2/3] [Model: add method to help in carrying out handling of co-requisites](https://github.com/CS2113-AY1819S2-T09-1/main/pull/197/commits/181b24e3fcb847d3c7485740bb4ecd47652060e0)
* [3/3] [Test: update test cases for 'planner_move' command](https://github.com/CS2113-AY1819S2-T09-1/main/pull/197/commits/ed22a52fa272b0c623ca762922e9932dbc4370e7)
