### PR TITLE
Logic: add new `Exception` for `BooleanExpressionParser`

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/FindCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/FindCommand.java
@@ -43,9 +43,6 @@ public class FindCommand extends Command {
             + OPERATOR_LEFT_BRACKET + " " + PREFIX_CODE + "CS1231 " + OPERATOR_OR + " " + PREFIX_CODE + "CS1010 "
             + OPERATOR_RIGHT_BRACKET + " ";
 
-    public static final String MESSAGE_INVALID_EXPRESSION =
-            "Invalid command format! (Filter expression is invalid) \n%1$s ";
-
     private final Predicate<Module> predicate;
 
     public FindCommand(Predicate<Module> predicate) {

--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -1,6 +1,5 @@
 package pwe.planner.logic.parser;
 
-import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
@@ -16,7 +15,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 
-import pwe.planner.logic.commands.FindCommand;
+import pwe.planner.logic.parser.exceptions.BooleanParserException;
+import pwe.planner.logic.parser.exceptions.BooleanParserPredicateException;
 import pwe.planner.logic.parser.exceptions.ParseException;
 import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
@@ -28,7 +28,22 @@ import pwe.planner.model.module.NameContainsKeywordsPredicate;
  */
 public class BooleanExpressionParser<T> {
 
+    public static final String MESSAGE_TIP = "[Tip] If you are unclear about the expected expression format, "
+            + "do check the help page.\nYou can do so by typing \"help\"";
+    public static final String MESSAGE_INVALID_EXPRESSION =
+            "Sorry! It look like an invalid command format! (Filter expression is invalid) \n%1$s";
+    public static final String MESSAGE_INVALID_OPERATOR = "This operator is not supported yet!";
+    public static final String MESSAGE_INVALID_OPERATOR_APPLICATION = "Perhaps you missed out one more criteria?\n"
+            + MESSAGE_TIP;
+    public static final String MESSAGE_UNABLE_TO_CREATE_PREDICATE = "No valid prefixes found";
+    public static final String MESSAGE_EMPTY_OUTPUT = "There seem to be an empty condition!\n"
+            + "Perhaps you might want to consider providing the criteria to filter?\n" + MESSAGE_TIP;
+    public static final String MESSAGE_GENERAL_FAIL = "You might want to check double check your filter expression!\n"
+            + MESSAGE_TIP;
+
+
     private static final String WHITESPACE = " ";
+
     private List<Prefix> prefixes;
     private String stringToTokenize;
 
@@ -38,7 +53,7 @@ public class BooleanExpressionParser<T> {
         this.prefixes = prefixes;
     }
 
-    private Predicate<T> getKeywordsPredicate(String args) throws ParseException {
+    private Predicate<T> getKeywordsPredicate(String args) throws BooleanParserPredicateException, ParseException {
         assert args != null;
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, prefixes.toArray(new Prefix[0]));
@@ -53,20 +68,21 @@ public class BooleanExpressionParser<T> {
             String creditKeyword = parseCredits(argMultimap.getValue(PREFIX_CREDITS).get()).toString();
             predicate = new CreditsContainsKeywordsPredicate<T>(List.of(creditKeyword));
         } else {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            throw new BooleanParserPredicateException(MESSAGE_UNABLE_TO_CREATE_PREDICATE);
         }
         return predicate;
     }
 
     /**
      * Apply the operator on the 2 predicates
+     *
      * @param operator
      * @param predicate1
      * @param predicate2
      * @return a composite predicate
      */
     private Predicate<T> applyOperator(Operator operator, Predicate<T> predicate1,
-            Predicate<T> predicate2) throws ParseException {
+                                       Predicate<T> predicate2) throws BooleanParserException {
         requireAllNonNull(operator, predicate1, predicate2);
 
         switch (operator) {
@@ -75,7 +91,7 @@ public class BooleanExpressionParser<T> {
         case AND:
             return predicate1.and(predicate2);
         default:
-            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+            throw new BooleanParserException(String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR));
         }
     }
 
@@ -83,9 +99,10 @@ public class BooleanExpressionParser<T> {
      * Parse input argument into a composite predicate.
      * This parse method make use of the shunting yard algorithm to convert in-fix to post fix then evaluate
      * the expression.
+     *
      * @return a composite predicate
      */
-    public Predicate<T> parse() throws ParseException {
+    public Predicate<T> parse() throws BooleanParserException, ParseException {
         BooleanExpressionTokenizer tokenizer = new BooleanExpressionTokenizer(stringToTokenize, prefixes);
 
         Deque<Predicate<T>> output = new ArrayDeque<>();
@@ -98,8 +115,8 @@ public class BooleanExpressionParser<T> {
                 switch (currentToken) {
                 case CliSyntax.OPERATOR_LEFT_BRACKET:
                     if (isNotExpectingLeftBracket) {
-                        throw new ParseException(
-                                String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+                        throw new BooleanParserException(String.format(MESSAGE_INVALID_EXPRESSION,
+                                MESSAGE_GENERAL_FAIL));
                     } else {
                         operatorStack.push(Operator.LEFT_BRACKET);
                         isNotExpectingLeftBracket = false;
@@ -133,7 +150,7 @@ public class BooleanExpressionParser<T> {
                 }
             }
         } catch (NoSuchElementException nse) {
-            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+            throw new BooleanParserException(String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_GENERAL_FAIL));
         }
 
         while (!operatorStack.isEmpty()) {
@@ -141,15 +158,20 @@ public class BooleanExpressionParser<T> {
             if (output.size() >= 2) {
                 output.push(applyOperator(operatorStack.pop(), output.pop(), output.pop()));
             } else {
-                throw new ParseException(
-                        String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+                throw new BooleanParserException(
+                        String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR_APPLICATION));
             }
         }
 
         // Output stack cannot have more than 1 predicate after shunting yard.
         // i.e. There is 2 predicate in an expression without a operator.
         if (output.size() > 1) {
-            throw new ParseException(String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+            throw new BooleanParserException(String.format(MESSAGE_INVALID_EXPRESSION,
+                    MESSAGE_INVALID_OPERATOR_APPLICATION));
+        }
+
+        if (output.size() == 0) {
+            throw new BooleanParserException(String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_EMPTY_OUTPUT));
         }
 
         assert output.size() == 1 : "output.size() should be 1.";

--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -29,16 +29,16 @@ import pwe.planner.model.module.NameContainsKeywordsPredicate;
 public class BooleanExpressionParser<T> {
 
     public static final String MESSAGE_TIP = "[Tip] If you are unclear about the expected expression format, "
-            + "do check the help page.\nYou can do so by typing \"help\"";
+            + "please check the help page.\nYou can do so by typing \"help\"";
     public static final String MESSAGE_INVALID_EXPRESSION =
-            "Sorry! It look like an invalid command format! (Filter expression is invalid) \n%1$s";
+            "It looks like an invalid command format! (Filter expression is invalid) \n%1$s";
     public static final String MESSAGE_INVALID_OPERATOR = "This operator is not supported yet!";
-    public static final String MESSAGE_INVALID_OPERATOR_APPLICATION = "Perhaps you missed out one more criteria?\n"
-            + MESSAGE_TIP;
+    public static final String MESSAGE_INVALID_OPERATOR_APPLICATION =
+            "Perhaps you missed out one or more search terms?\n" + MESSAGE_TIP;
     public static final String MESSAGE_UNABLE_TO_CREATE_PREDICATE = "No valid prefixes found";
-    public static final String MESSAGE_EMPTY_OUTPUT = "There seem to be an empty condition!\n"
+    public static final String MESSAGE_EMPTY_OUTPUT = "There seems to be an empty condition!\n"
             + "Perhaps you might want to consider providing the criteria to filter?\n" + MESSAGE_TIP;
-    public static final String MESSAGE_GENERAL_FAIL = "You might want to check double check your filter expression!\n"
+    public static final String MESSAGE_GENERAL_FAIL = "You might want to double check your filter expression!\n"
             + MESSAGE_TIP;
 
 

--- a/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
@@ -2,6 +2,7 @@ package pwe.planner.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.commands.FindCommand.MESSAGE_USAGE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
@@ -10,6 +11,8 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import pwe.planner.logic.commands.FindCommand;
+import pwe.planner.logic.parser.exceptions.BooleanParserException;
+import pwe.planner.logic.parser.exceptions.BooleanParserPredicateException;
 import pwe.planner.logic.parser.exceptions.ParseException;
 import pwe.planner.model.module.Module;
 
@@ -34,11 +37,17 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
         }
-        BooleanExpressionParser<Module> expressionParser = new BooleanExpressionParser<>(args, PREFIXES);
-        Predicate<Module> predicate = expressionParser.parse();
-        return new FindCommand(predicate);
+        try {
+            BooleanExpressionParser<Module> expressionParser = new BooleanExpressionParser<>(args, PREFIXES);
+            Predicate<Module> predicate = expressionParser.parse();
+            return new FindCommand(predicate);
+        } catch (BooleanParserPredicateException predicateException) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+        } catch (BooleanParserException parserException) {
+            throw new ParseException(parserException.getMessage());
+        }
     }
 
 }

--- a/src/main/java/pwe/planner/logic/parser/exceptions/BooleanParserException.java
+++ b/src/main/java/pwe/planner/logic/parser/exceptions/BooleanParserException.java
@@ -1,0 +1,16 @@
+package pwe.planner.logic.parser.exceptions;
+
+import pwe.planner.commons.exceptions.IllegalValueException;
+
+/**
+ * Represent a boolean parser exceptions when handling the logic.
+ */
+public class BooleanParserException extends IllegalValueException {
+    public BooleanParserException(String message) {
+        super(message);
+    }
+
+    public BooleanParserException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/pwe/planner/logic/parser/exceptions/BooleanParserPredicateException.java
+++ b/src/main/java/pwe/planner/logic/parser/exceptions/BooleanParserPredicateException.java
@@ -1,0 +1,14 @@
+package pwe.planner.logic.parser.exceptions;
+
+/**
+ *  Boolean Parser exception when trying to create a predicate from keyword.
+ */
+public class BooleanParserPredicateException extends BooleanParserException {
+    public BooleanParserPredicateException(String message) {
+        super(message);
+    }
+
+    public BooleanParserPredicateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
@@ -24,6 +24,7 @@ import pwe.planner.model.ModelManager;
 import pwe.planner.model.UserPrefs;
 import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
+import pwe.planner.model.module.Module;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
 import pwe.planner.storage.JsonSerializableApplication;
 
@@ -44,10 +45,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        NameContainsKeywordsPredicate<Module> firstPredicate =
+                new NameContainsKeywordsPredicate<>(Collections.singletonList("first"));
+        NameContainsKeywordsPredicate<Module> secondPredicate =
+                new NameContainsKeywordsPredicate<>(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -72,7 +73,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noModuleFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
+        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -82,7 +83,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleNameKeywords_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -93,7 +94,7 @@ public class FindCommandTest {
     public void execute_multipleCodeKeywords_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
         // TODO: update the module code after TypicalModule attribute are updated
-        CodeContainsKeywordsPredicate predicate = prepareCodePredicate("CS2040C CS2101 CS2102");
+        CodeContainsKeywordsPredicate<Module> predicate = prepareCodePredicate("CS2040C CS2101 CS2102");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -104,7 +105,7 @@ public class FindCommandTest {
     public void execute_multipleCreditsKeywords_multipleModulesFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
         // TODO: update the module credits after TypicalModule attribute are updated
-        CreditsContainsKeywordsPredicate predicate = prepareCreditsPredicate("2 4 5");
+        CreditsContainsKeywordsPredicate<Module> predicate = prepareCreditsPredicate("2 4 5");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -114,22 +115,22 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private NameContainsKeywordsPredicate<Module> prepareNamePredicate(String userInput) {
+        return new NameContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
     }
 
     /**
      * Parses {@code userInput} into a {@code CodeContainsKeywordsPredicate}.
      */
-    private CodeContainsKeywordsPredicate prepareCodePredicate(String userInput) {
-        return new CodeContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private CodeContainsKeywordsPredicate<Module> prepareCodePredicate(String userInput) {
+        return new CodeContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
     }
 
     /**
      * Parses {@code userInput} into a {@code CreditsContainsKeywordsPredicate}.
      */
-    private CreditsContainsKeywordsPredicate prepareCreditsPredicate(String userInput) {
-        return new CreditsContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private CreditsContainsKeywordsPredicate<Module> prepareCreditsPredicate(String userInput) {
+        return new CreditsContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
     }
 
 }

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -95,7 +95,7 @@ public class CommandParserTest {
         List<String> keywords = Arrays.asList("foo");
         FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " "
                 + PREFIX_NAME + "foo");
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate<>(keywords)), command);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
@@ -46,17 +46,17 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindNameCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice")));
+                new FindCommand(new NameContainsKeywordsPredicate<>(Arrays.asList("Alice")));
         // single keyword
         assertParseSuccess(parser, PREFIX_NAME + "Alice", expectedFindNameCommand);
 
         FindCommand expectedFindCodeCommand =
-                new FindCommand(new CodeContainsKeywordsPredicate(Arrays.asList("CS1231")));
+                new FindCommand(new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1231")));
         // single keyword
         assertParseSuccess(parser, PREFIX_CODE + "CS1231", expectedFindCodeCommand);
 
         FindCommand expectedFindCreditsCommand =
-                new FindCommand(new CreditsContainsKeywordsPredicate(Arrays.asList("999")));
+                new FindCommand(new CreditsContainsKeywordsPredicate<>(Arrays.asList("999")));
         // single keyword
         assertParseSuccess(parser, PREFIX_CREDITS + "999", expectedFindCreditsCommand);
     }

--- a/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_OR;
+import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
@@ -83,11 +85,40 @@ public class FindCommandParserTest {
         assertParserSuccess(parser, PREFIX_CREDITS + "4 " + WHITESPACE + OPERATOR_AND + WHITESPACE
                 + PREFIX_CREDITS + "999");
 
+        // test for boolean AND and boolean OR
+        // credits/CREDITS || credits/CREDITS && name/Programming
+        assertParserSuccess(parser, PREFIX_CREDITS + "4 " + WHITESPACE + OPERATOR_OR + WHITESPACE
+                + PREFIX_CREDITS + "999" + OPERATOR_AND + PREFIX_NAME + "programming");
+
+        // credits/4 || (name/Information && name/Security)
+        assertParserSuccess(parser, PREFIX_CREDITS + "4" + OPERATOR_OR + OPERATOR_LEFT_BRACKET + PREFIX_NAME
+                + "information" + OPERATOR_AND + PREFIX_NAME + "security" + OPERATOR_RIGHT_BRACKET);
+
     }
 
     @Test
     public void parseInvalidArgs() {
         assertParseThrowsException(parser, "invalid/DoesNotExists");
+        // name/Programming code/CS1231
+        assertParseThrowsException(parser, PREFIX_NAME + "Programming " + PREFIX_CODE + "CS1231");
+        // ()
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET);
+        // ()()
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET + OPERATOR_LEFT_BRACKET
+                + OPERATOR_RIGHT_BRACKET);
+        // ())
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + OPERATOR_RIGHT_BRACKET + OPERATOR_RIGHT_BRACKET);
+        // name/Programming ) code/CS1231
+        assertParseThrowsException(parser, PREFIX_NAME + "Programming " + OPERATOR_RIGHT_BRACKET + PREFIX_CODE
+                + "CS1231");
+        // (name/Programming || code/CS1231
+        assertParseThrowsException(parser, OPERATOR_LEFT_BRACKET + PREFIX_NAME + "Programming" + OPERATOR_OR
+                + PREFIX_CODE + "CS1231");
+        // credits/4 || (name/Programming AND code/CS1231))
+        assertParseThrowsException(parser, PREFIX_CREDITS + "4" + OPERATOR_OR + OPERATOR_LEFT_BRACKET + PREFIX_NAME
+                + "Programming" + OPERATOR_AND + PREFIX_CODE + "CS1231" + OPERATOR_RIGHT_BRACKET
+                + OPERATOR_RIGHT_BRACKET);
+
     }
 
     /**

--- a/src/test/java/pwe/planner/model/ModelManagerTest.java
+++ b/src/test/java/pwe/planner/model/ModelManagerTest.java
@@ -181,7 +181,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredModuleList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(Arrays.asList(keywords)));
 
         assertFalse(modelManager
                 .equals(new ModelManager(application, userPrefs)));

--- a/src/test/java/pwe/planner/model/module/CodeContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/CodeContainsKeywordsPredicateTest.java
@@ -17,17 +17,17 @@ public class CodeContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        CodeContainsKeywordsPredicate firstPredicate =
-                new CodeContainsKeywordsPredicate(firstPredicateKeywordList);
-        CodeContainsKeywordsPredicate secondPredicate =
-                new CodeContainsKeywordsPredicate(secondPredicateKeywordList);
+        CodeContainsKeywordsPredicate<Module> firstPredicate =
+                new CodeContainsKeywordsPredicate<>(firstPredicateKeywordList);
+        CodeContainsKeywordsPredicate<Module> secondPredicate =
+                new CodeContainsKeywordsPredicate<>(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        CodeContainsKeywordsPredicate firstPredicateCopy =
-                new CodeContainsKeywordsPredicate(firstPredicateKeywordList);
+        CodeContainsKeywordsPredicate<Module> firstPredicateCopy =
+                new CodeContainsKeywordsPredicate<>(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -43,17 +43,17 @@ public class CodeContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        CodeContainsKeywordsPredicate predicate =
-                new CodeContainsKeywordsPredicate(Collections.singletonList("CS1010"));
+        CodeContainsKeywordsPredicate<Module> predicate =
+                new CodeContainsKeywordsPredicate<>(Collections.singletonList("CS1010"));
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
 
         // Multiple keywords
-        predicate = new CodeContainsKeywordsPredicate(Arrays.asList("CS1010", "CS1231"));
+        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1010", "CS1231"));
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1231").build()));
 
         // Mixed-case keywords
-        predicate = new CodeContainsKeywordsPredicate(Arrays.asList("cS1010", "Cs1231"));
+        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("cS1010", "Cs1231"));
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1231").build()));
     }
@@ -61,15 +61,15 @@ public class CodeContainsKeywordsPredicateTest {
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        CodeContainsKeywordsPredicate predicate = new CodeContainsKeywordsPredicate(Collections.emptyList());
+        CodeContainsKeywordsPredicate<Module> predicate = new CodeContainsKeywordsPredicate<>(Collections.emptyList());
         assertFalse(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
 
         // Non-matching keyword
-        predicate = new CodeContainsKeywordsPredicate(Arrays.asList("CS1000"));
+        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1000"));
         assertFalse(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
 
         // Keywords match credits and name, but does not match code
-        predicate = new CodeContainsKeywordsPredicate(Arrays.asList("CS0000", "CS1111"));
+        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS0000", "CS1111"));
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }

--- a/src/test/java/pwe/planner/model/module/CreditsContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/CreditsContainsKeywordsPredicateTest.java
@@ -18,17 +18,17 @@ public class CreditsContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("1 2");
         List<String> secondPredicateKeywordList = Arrays.asList("1", "1");
 
-        CreditsContainsKeywordsPredicate firstPredicate =
-                new CreditsContainsKeywordsPredicate(firstPredicateKeywordList);
-        CreditsContainsKeywordsPredicate secondPredicate =
-                new CreditsContainsKeywordsPredicate(secondPredicateKeywordList);
+        CreditsContainsKeywordsPredicate<Module> firstPredicate =
+                new CreditsContainsKeywordsPredicate<>(firstPredicateKeywordList);
+        CreditsContainsKeywordsPredicate<Module> secondPredicate =
+                new CreditsContainsKeywordsPredicate<>(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        CreditsContainsKeywordsPredicate firstPredicateCopy =
-                new CreditsContainsKeywordsPredicate(firstPredicateKeywordList);
+        CreditsContainsKeywordsPredicate<Module> firstPredicateCopy =
+                new CreditsContainsKeywordsPredicate<>(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -44,27 +44,28 @@ public class CreditsContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        CreditsContainsKeywordsPredicate predicate =
-                new CreditsContainsKeywordsPredicate(Collections.singletonList("444"));
+        CreditsContainsKeywordsPredicate<Module> predicate =
+                new CreditsContainsKeywordsPredicate<>(Collections.singletonList("444"));
         assertTrue(predicate.test(new ModuleBuilder().withCredits("444").build()));
 
         // Multiple keywords
-        predicate = new CreditsContainsKeywordsPredicate(Arrays.asList("122", "444"));
+        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("122", "444"));
         assertTrue(predicate.test(new ModuleBuilder().withCredits("122").build()));
 
         // Only one matching keyword
-        predicate = new CreditsContainsKeywordsPredicate(Arrays.asList("999", "444"));
+        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("999", "444"));
         assertTrue(predicate.test(new ModuleBuilder().withCredits("444").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        CreditsContainsKeywordsPredicate predicate = new CreditsContainsKeywordsPredicate(Collections.emptyList());
+        CreditsContainsKeywordsPredicate<Module> predicate = new CreditsContainsKeywordsPredicate<>(
+                Collections.emptyList());
         assertFalse(predicate.test(new ModuleBuilder().withCredits("123").build()));
 
         // Non-matching keyword
-        predicate = new CreditsContainsKeywordsPredicate(Arrays.asList("144"));
+        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("144"));
         assertFalse(predicate.test(new ModuleBuilder().withCredits("441").build()));
     }
 }

--- a/src/test/java/pwe/planner/model/module/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/NameContainsKeywordsPredicateTest.java
@@ -18,14 +18,17 @@ public class NameContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        NameContainsKeywordsPredicate<Module> firstPredicate = new NameContainsKeywordsPredicate<>(
+                firstPredicateKeywordList);
+        NameContainsKeywordsPredicate<Module> secondPredicate = new NameContainsKeywordsPredicate<>(
+                secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate<Module> firstPredicateCopy = new NameContainsKeywordsPredicate<>(
+                firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,34 +44,36 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        NameContainsKeywordsPredicate<Module> predicate = new NameContainsKeywordsPredicate<>(
+                Collections.singletonList("Alice"));
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Bob", "Carol"));
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        NameContainsKeywordsPredicate<Module> predicate = new NameContainsKeywordsPredicate<>(
+                Collections.emptyList());
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Carol"));
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
         // Keywords match credits and code, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("12345", "Main", "Street"));
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertFalse;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
 import static pwe.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_INVALID_EXPRESSION;
+import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_INVALID_OPERATOR_APPLICATION;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_LEFT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_OR;
@@ -26,6 +28,7 @@ import pwe.planner.logic.commands.DeleteCommand;
 import pwe.planner.logic.commands.FindCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.UndoCommand;
+import pwe.planner.logic.parser.BooleanExpressionParser;
 import pwe.planner.model.Model;
 import pwe.planner.model.tag.Tag;
 
@@ -291,10 +294,10 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
     public void negativeTest() {
         // invalid operator
         String command = FindCommand.COMMAND_WORD + " name/Programming !! code/CS1231";
-        assertCommandFailure(command, String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR_APPLICATION));
         // invalid operator
         command = FindCommand.COMMAND_WORD + " name/Programming ## code/CS1231";
-        assertCommandFailure(command, String.format(FindCommand.MESSAGE_INVALID_EXPRESSION, FindCommand.MESSAGE_USAGE));
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR_APPLICATION));
         // valid + invalid prefix
         command = FindCommand.COMMAND_WORD + " name/Programming " + OPERATOR_OR + " nonExisting/CS1231";
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -304,8 +307,6 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
         // single invalid prefix with multiple white space
         command = FindCommand.COMMAND_WORD + "                          nonExisting/CS1231                ";
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-
-
     }
 
     /**

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertFalse;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
 import static pwe.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_EMPTY_OUTPUT;
+import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_GENERAL_FAIL;
 import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_INVALID_EXPRESSION;
 import static pwe.planner.logic.parser.BooleanExpressionParser.MESSAGE_INVALID_OPERATOR_APPLICATION;
 import static pwe.planner.logic.parser.CliSyntax.OPERATOR_AND;
@@ -28,7 +30,6 @@ import pwe.planner.logic.commands.DeleteCommand;
 import pwe.planner.logic.commands.FindCommand;
 import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.UndoCommand;
-import pwe.planner.logic.parser.BooleanExpressionParser;
 import pwe.planner.model.Model;
 import pwe.planner.model.tag.Tag;
 
@@ -298,6 +299,11 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
         // invalid operator
         command = FindCommand.COMMAND_WORD + " name/Programming ## code/CS1231";
         assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR_APPLICATION));
+
+        // missing operator
+        command = FindCommand.COMMAND_WORD + " name/Programming code/CS1231";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_INVALID_OPERATOR_APPLICATION));
+
         // valid + invalid prefix
         command = FindCommand.COMMAND_WORD + " name/Programming " + OPERATOR_OR + " nonExisting/CS1231";
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -307,6 +313,15 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
         // single invalid prefix with multiple white space
         command = FindCommand.COMMAND_WORD + "                          nonExisting/CS1231                ";
         assertCommandFailure(command, String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        // empty criteria with ()
+        command = FindCommand.COMMAND_WORD + " ()";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_EMPTY_OUTPUT));
+
+        command = FindCommand.COMMAND_WORD + " (name/Programming))";
+        assertCommandFailure(command, String.format(MESSAGE_INVALID_EXPRESSION, MESSAGE_GENERAL_FAIL));
+
+
     }
 
     /**


### PR DESCRIPTION
We have generalized our `BooleanExpressionParser`, however the exception
that is being thrown now is all related to `FindCommand`.

Let's remove all the `FindCommand` exceptions and create a more
general exception for `BooleanExpressionParser` and:
* cascade the changes to all affected class
* fixed broken test 
* fix uncheck type for all generic

We should also add new unit tests to ensure the behaviour of our 
`BooleanExpressionParser`.

* [1/4] [Logic: add new `Exception` for `BooleanExpressionParser`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/199/commits/4f2d5a1a21c5dc3ed0ca49c54701c68d0e6e4211)
* [2/4] [parser/Test: add new unit tests related to new `Exception`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/199/commits/cb535d7e45f5c6ec49f9103129b87d0f4e998c7e)
* [3/4] [systemtest/FindCommandSystemTest: add new unit tests related to new `Exception`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/199/commits/426987281b743f812d71b189703dd96ef6c0ca82)
* [4/4] [parser/Test: uncheck type after `BooleanExpressionParser` was made generic](https://github.com/CS2113-AY1819S2-T09-1/main/pull/199/commits/951c4471c0801b74b3cf93f12f51a606c61902c1)
