### PR TITLE
Model/module: add `Module#semesters`

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/AddCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/AddCommand.java
@@ -5,6 +5,7 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import pwe.planner.logic.CommandHistory;
@@ -26,12 +27,15 @@ public class AddCommand extends Command {
             + PREFIX_CODE + "CODE "
             + PREFIX_NAME + "NAME "
             + PREFIX_CREDITS + "CREDITS "
+            + "[" + PREFIX_SEMESTER + "SEMESTER]... "
             + "[" + PREFIX_COREQUISITE + "COREQUISITE]... "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_CODE + "CS2113T "
             + PREFIX_NAME + "Software Engineering and Object-Oriented Programming "
             + PREFIX_CREDITS + "4 "
+            + PREFIX_SEMESTER + "1 "
+            + PREFIX_SEMESTER + "2 "
             + PREFIX_COREQUISITE + "CS2101 "
             + PREFIX_TAG + "OOP "
             + PREFIX_TAG + "RCS "

--- a/src/main/java/pwe/planner/logic/parser/AddCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/AddCommandParser.java
@@ -6,12 +6,14 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static pwe.planner.logic.parser.ParserUtil.arePrefixesPresent;
 import static pwe.planner.logic.parser.ParserUtil.parseCode;
 import static pwe.planner.logic.parser.ParserUtil.parseCorequisites;
 import static pwe.planner.logic.parser.ParserUtil.parseCredits;
 import static pwe.planner.logic.parser.ParserUtil.parseName;
+import static pwe.planner.logic.parser.ParserUtil.parseSemesters;
 import static pwe.planner.logic.parser.ParserUtil.parseTags;
 
 import java.util.Set;
@@ -22,6 +24,7 @@ import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
 /**
@@ -42,10 +45,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, PREFIX_NAME, PREFIX_CREDITS, PREFIX_CODE, PREFIX_TAG, PREFIX_COREQUISITE
+                args, PREFIX_CODE, PREFIX_NAME, PREFIX_CREDITS, PREFIX_SEMESTER, PREFIX_COREQUISITE, PREFIX_TAG
         );
 
-        boolean isAnyRequiredPrefixAbsent = !arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE, PREFIX_CREDITS);
+        boolean isAnyRequiredPrefixAbsent = !arePrefixesPresent(argMultimap, PREFIX_CODE, PREFIX_NAME, PREFIX_CREDITS);
+
         if (isAnyRequiredPrefixAbsent || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -53,10 +57,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Code code = parseCode(argMultimap.getValue(PREFIX_CODE).get());
         Name name = parseName(argMultimap.getValue(PREFIX_NAME).get());
         Credits credits = parseCredits(argMultimap.getValue(PREFIX_CREDITS).get());
-        Set<Code> corequisiteList = parseCorequisites(argMultimap.getAllValues(PREFIX_COREQUISITE));
-        Set<Tag> tagList = parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Semester> semesterSet = parseSemesters(argMultimap.getAllValues(PREFIX_SEMESTER));
+        Set<Code> corequisiteSet = parseCorequisites(argMultimap.getAllValues(PREFIX_COREQUISITE));
+        Set<Tag> tagSet = parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Module module = new Module(name, credits, code, tagList, corequisiteList);
+        Module module = new Module(code, name, credits, semesterSet, corequisiteSet, tagSet);
         return new AddCommand(module);
     }
 }

--- a/src/main/java/pwe/planner/logic/parser/ParserUtil.java
+++ b/src/main/java/pwe/planner/logic/parser/ParserUtil.java
@@ -132,6 +132,19 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> semesters} into a {@code Set<Semester>}.<br>
+     */
+    public static Set<Semester> parseSemesters(Collection<String> semesters) throws ParseException {
+        requireNonNull(semesters);
+
+        final Set<Semester> semesterSet = new HashSet<>();
+        for (String semester : semesters) {
+            semesterSet.add(parseSemester(semester));
+        }
+        return semesterSet;
+    }
+
+    /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/pwe/planner/model/module/Module.java
+++ b/src/main/java/pwe/planner/model/module/Module.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
 /**
@@ -19,8 +20,9 @@ public class Module {
      * The format string representation of a {@link Module} object used by {@link Module#toString()}.
      */
     private static final String STRING_REPRESENTATION = "%1$s %2$s (%3$s Modular Credits)\n"
-            + "Co-requisites: %4$s\n"
-            + "Tags: %5$s";
+            + "Offered in Semesters: %4$s\n"
+            + "Co-requisites: %5$s\n"
+            + "Tags: %6$s";
 
     // Identity fields
     private final Code code;
@@ -30,18 +32,25 @@ public class Module {
     private final Credits credits;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Code> corequisites = new HashSet<>();
+    private final Set<Semester> semesters = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Module(Name name, Credits credits, Code code, Set<Tag> tags, Set<Code> corequisites) {
-        requireAllNonNull(name, credits, code, tags, corequisites);
+    public Module(Code code, Name name, Credits credits, Set<Semester> semesters, Set<Code> corequisites,
+            Set<Tag> tags) {
+        requireAllNonNull(code, name, credits, semesters, corequisites, tags);
 
+        this.code = code;
         this.name = name;
         this.credits = credits;
-        this.code = code;
-        this.tags.addAll(tags);
+        this.semesters.addAll(semesters);
         this.corequisites.addAll(corequisites);
+        this.tags.addAll(tags);
+    }
+
+    public Code getCode() {
+        return code;
     }
 
     public Name getName() {
@@ -52,16 +61,12 @@ public class Module {
         return credits;
     }
 
-    public Code getCode() {
-        return code;
-    }
-
     /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable {@code Semester} set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public Set<Tag> getTags() {
-        return Collections.unmodifiableSet(tags);
+    public Set<Semester> getSemesters() {
+        return Collections.unmodifiableSet(semesters);
     }
 
     /**
@@ -70,6 +75,14 @@ public class Module {
      */
     public Set<Code> getCorequisites() {
         return Collections.unmodifiableSet(corequisites);
+    }
+
+    /**
+     * Returns an immutable {@code Tag} set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Tag> getTags() {
+        return Collections.unmodifiableSet(tags);
     }
 
     /**
@@ -99,21 +112,26 @@ public class Module {
         }
 
         Module otherModule = (Module) other;
-        return otherModule.getName().equals(getName())
+        return otherModule.getCode().equals(getCode())
+                && otherModule.getName().equals(getName())
                 && otherModule.getCredits().equals(getCredits())
-                && otherModule.getCode().equals(getCode())
-                && otherModule.getTags().equals(getTags())
-                && otherModule.getCorequisites().equals(getCorequisites());
+                && otherModule.getCorequisites().equals(getCorequisites())
+                && otherModule.getSemesters().equals(getSemesters())
+                && otherModule.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
-        // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, credits, code, tags, corequisites);
+        return Objects.hash(code, name, credits, semesters, corequisites, tags);
     }
 
     @Override
     public String toString() {
+
+        final String allSemesters = semesters.isEmpty()
+                ? "None"
+                : semesters.stream().sorted().map(Semester::toString).collect(Collectors.joining(", "));
+
         final String allCorequisites = corequisites.isEmpty()
                 ? "None"
                 : corequisites.stream().sorted().map(Code::toString).collect(Collectors.joining(", "));
@@ -122,7 +140,6 @@ public class Module {
                 ? "None"
                 : tags.stream().sorted().map(Tag::toString).collect(Collectors.joining(", "));
 
-        return String.format(STRING_REPRESENTATION, code, name, credits, allCorequisites, allTags);
+        return String.format(STRING_REPRESENTATION, code, name, credits, allSemesters, allCorequisites, allTags);
     }
-
 }

--- a/src/main/java/pwe/planner/model/module/UniqueModuleList.java
+++ b/src/main/java/pwe/planner/model/module/UniqueModuleList.java
@@ -105,11 +105,12 @@ public class UniqueModuleList implements Iterable<Module> {
                 editedOtherCorequisites.remove(otherModule.getCode());
 
                 Module editedOtherModule = new Module(
+                        otherModule.getCode(),
                         otherModule.getName(),
                         otherModule.getCredits(),
-                        otherModule.getCode(),
-                        otherModule.getTags(),
-                        editedOtherCorequisites
+                        otherModule.getSemesters(),
+                        editedOtherCorequisites,
+                        otherModule.getTags()
                 );
 
                 setModule(otherModule, editedOtherModule, false);
@@ -177,11 +178,12 @@ public class UniqueModuleList implements Iterable<Module> {
                 editedCorequisiteCodes.add(editedCode);
 
                 Module editedCorequisiteModule = new Module(
+                        module.getCode(),
                         module.getName(),
                         module.getCredits(),
-                        module.getCode(),
-                        module.getTags(),
-                        editedCorequisiteCodes
+                        module.getSemesters(),
+                        editedCorequisiteCodes,
+                        module.getTags()
                 );
 
                 setModule(module, editedCorequisiteModule, false);
@@ -219,11 +221,12 @@ public class UniqueModuleList implements Iterable<Module> {
                 editedCorequisiteCodes.remove(codeToDelete);
 
                 Module editedModule = new Module(
+                        module.getCode(),
                         module.getName(),
                         module.getCredits(),
-                        module.getCode(),
-                        module.getTags(),
-                        editedCorequisiteCodes
+                        module.getSemesters(),
+                        editedCorequisiteCodes,
+                        module.getTags()
                 );
 
                 setModule(module, editedModule, false);

--- a/src/main/java/pwe/planner/model/util/SampleDataUtil.java
+++ b/src/main/java/pwe/planner/model/util/SampleDataUtil.java
@@ -23,43 +23,48 @@ import pwe.planner.model.tag.Tag;
  */
 public class SampleDataUtil {
     private static final Module CS1010 = new Module(
+            new Code("CS1010"),
             new Name("Programming Methodology"),
             new Credits("4"),
-            new Code("CS1010"),
-            getTagSet("programming", "algorithms", "c", "imperative"),
-            getCodeSet()
+            getSemesterSet("1", "2", "4"),
+            getCorequisiteSet(),
+            getTagSet("programming", "algorithms", "c", "imperative")
     );
 
     private static final Module CS1231 = new Module(
+            new Code("CS1231"),
             new Name("Discrete Structures"),
             new Credits("4"),
-            new Code("CS1231"),
-            getTagSet("math", "logic", "proving"),
-            getCodeSet()
+            getSemesterSet("1", "2"),
+            getCorequisiteSet(),
+            getTagSet("math", "logic", "proving")
     );
 
     private static final Module CS2040C = new Module(
+            new Code("CS2040C"),
             new Name("Data Structures and Algorithms"),
             new Credits("4"),
-            new Code("CS2040C"),
-            getTagSet("linkedlist", "stack", "queue", "hashtable", "heap", "avltree", "graph", "sssp"),
-            getCodeSet()
+            getSemesterSet("1", "2"),
+            getCorequisiteSet(),
+            getTagSet("linkedlist", "stack", "queue", "hashtable", "heap", "avltree", "graph", "sssp")
     );
 
     private static final Module CS2100 = new Module(
+            new Code("CS2100"),
             new Name("Computer Organisation"),
             new Credits("4"),
-            new Code("CS2100"),
-            getTagSet("boolean", "mips", "assembly", "circuit", "flipflop", "pipelining", "cache"),
-            getCodeSet()
+            getSemesterSet("1", "2"),
+            getCorequisiteSet(),
+            getTagSet("boolean", "mips", "assembly", "circuit", "flipflop", "pipelining", "cache")
     );
 
     private static final Module CS2102 = new Module(
+            new Code("CS2102"),
             new Name("Database Systems"),
             new Credits("4"),
-            new Code("CS2102"),
-            getTagSet("database", "rdbms", "entity", "sql", "normalisation"),
-            getCodeSet()
+            getSemesterSet("1", "2"),
+            getCorequisiteSet(),
+            getTagSet("database", "rdbms", "entity", "sql", "normalisation")
     );
 
     private static final DegreePlanner YEAR_1_SEMESTER_1 = new DegreePlanner(
@@ -163,31 +168,45 @@ public class SampleDataUtil {
             getCodeSet("CS1010", "CS1231", "CS2040C", "CS2100", "CS2102")
     );
     private static final RequirementCategory INFORMATION_SECURITY_REQUIREMENTS = new RequirementCategory(
-            new Name("Information Security Requirements"), new Credits("20"), getCodeSet()
+            new Name("Information Security Requirements"),
+            new Credits("20"),
+            getCodeSet()
     );
 
     private static final RequirementCategory INFORMATION_SECURITY_ELECTIVES = new RequirementCategory(
-            new Name("Information Security Electives"), new Credits("12"), getCodeSet()
+            new Name("Information Security Electives"),
+            new Credits("12"),
+            getCodeSet()
     );
 
     private static final RequirementCategory COMPUTING_BREADTH = new RequirementCategory(
-            new Name("Computing Breadth"), new Credits("20"), getCodeSet()
+            new Name("Computing Breadth"),
+            new Credits("20"),
+            getCodeSet()
     );
 
     private static final RequirementCategory IT_PROFESSIONALISM = new RequirementCategory(
-            new Name("IT Professionalism"), new Credits("8"), getCodeSet()
+            new Name("IT Professionalism"),
+            new Credits("8"),
+            getCodeSet()
     );
 
     private static final RequirementCategory MATHEMATICS = new RequirementCategory(
-            new Name("Mathematics"), new Credits("12"), getCodeSet()
+            new Name("Mathematics"),
+            new Credits("12"),
+            getCodeSet()
     );
 
     private static final RequirementCategory GENERAL_EDUCATION = new RequirementCategory(
-            new Name("General Education"), new Credits("20"), getCodeSet()
+            new Name("General Education"),
+            new Credits("20"),
+            getCodeSet()
     );
 
     private static final RequirementCategory UNRESTRICTED_ELECTIVES = new RequirementCategory(
-            new Name("Unrestricted Electives"), new Credits("12"), getCodeSet()
+            new Name("Unrestricted Electives"),
+            new Credits("12"),
+            getCodeSet()
     );
 
     public static Module[] getSampleModules() {
@@ -245,6 +264,17 @@ public class SampleDataUtil {
     }
 
     /**
+     * Returns a semester set containing the list of strings given.
+     */
+    public static Set<Semester> getSemesterSet(String... strings) {
+        requireNonNull(strings);
+
+        return Arrays.stream(strings)
+                .map(Semester::new)
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * Returns a code set containing the list of strings given.
      */
     public static Set<Code> getCodeSet(String... strings) {
@@ -253,6 +283,14 @@ public class SampleDataUtil {
         return Arrays.stream(strings)
                 .map(Code::new)
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns a code set containing the list of strings given.
+     * Syntactic sugar for {@link #getCodeSet(String...)}
+     */
+    public static Set<Code> getCorequisiteSet(String... strings) {
+        return getCodeSet(strings);
     }
 
     /**

--- a/src/main/java/pwe/planner/storage/JsonAdaptedModule.java
+++ b/src/main/java/pwe/planner/storage/JsonAdaptedModule.java
@@ -16,6 +16,7 @@ import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
 /**
@@ -25,29 +26,36 @@ class JsonAdaptedModule {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Module's %s field is missing!";
 
+    private final String code;
     private final String name;
     private final String credits;
-    private final String code;
-    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final List<JsonAdaptedSemester> semesters = new ArrayList<>();
     private final List<JsonAdaptedCode> corequisites = new ArrayList<>();
-
+    private final List<JsonAdaptedTag> tags = new ArrayList<>();
     /**
      * Constructs a {@code JsonAdaptedModule} with the given module details.
      */
     @JsonCreator
-    public JsonAdaptedModule(@JsonProperty("name") String name, @JsonProperty("credits") String credits,
-            @JsonProperty("code") String code, @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-            @JsonProperty("corequisites") List<JsonAdaptedCode> corequisites) {
+    public JsonAdaptedModule(@JsonProperty("code") String code,
+            @JsonProperty("name") String name,
+            @JsonProperty("credits") String credits,
+            @JsonProperty("semesters") List<JsonAdaptedSemester> semesters,
+            @JsonProperty("corequisites") List<JsonAdaptedCode> corequisites,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tags) {
+        this.code = code;
         this.name = name;
         this.credits = credits;
-        this.code = code;
 
-        if (tagged != null) {
-            this.tagged.addAll(tagged);
+        if (semesters != null) {
+            this.semesters.addAll(semesters);
         }
 
         if (corequisites != null) {
             this.corequisites.addAll(corequisites);
+        }
+
+        if (tags != null) {
+            this.tags.addAll(tags);
         }
     }
 
@@ -57,15 +65,12 @@ class JsonAdaptedModule {
     public JsonAdaptedModule(Module source) {
         requireNonNull(source);
 
+        code = source.getCode().value;
         name = source.getName().fullName;
         credits = source.getCredits().value;
-        code = source.getCode().value;
-        tagged.addAll(source.getTags().stream()
-                .map(JsonAdaptedTag::new)
-                .collect(Collectors.toList()));
-        corequisites.addAll(source.getCorequisites().stream()
-                .map(JsonAdaptedCode::new)
-                .collect(Collectors.toList()));
+        semesters.addAll(source.getSemesters().stream().map(JsonAdaptedSemester::new).collect(Collectors.toList()));
+        corequisites.addAll(source.getCorequisites().stream().map(JsonAdaptedCode::new).collect(Collectors.toList()));
+        tags.addAll(source.getTags().stream().map(JsonAdaptedTag::new).collect(Collectors.toList()));
     }
 
     /**
@@ -74,43 +79,59 @@ class JsonAdaptedModule {
      * @throws IllegalValueException if there were any data constraints violated in the adapted module.
      */
     public Module toModelType() throws IllegalValueException {
-        final List<Tag> moduleTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tagged) {
-            moduleTags.add(tag.toModelType());
-        }
-
-        final List<Code> moduleCorequisites = new ArrayList<>();
-        for (JsonAdaptedCode corequisite : corequisites) {
-            moduleCorequisites.add(corequisite.toModelType());
-        }
-
-        if (name == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
-        }
-        if (!Name.isValidName(name)) {
-            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
-        }
-        final Name modelName = new Name(name);
-
-        if (credits == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Credits.class.getSimpleName()));
-        }
-        if (!Credits.isValidCredits(credits)) {
-            throw new IllegalValueException(Credits.MESSAGE_CONSTRAINTS);
-        }
-        final Credits modelCredits = new Credits(credits);
-
+        // Check valid Code
         if (code == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Code.class.getSimpleName()));
+            String exceptionMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Code.class.getSimpleName());
+            throw new IllegalValueException(exceptionMessage);
         }
         if (!Code.isValidCode(code)) {
             throw new IllegalValueException(Code.MESSAGE_CONSTRAINTS);
         }
         final Code modelCode = new Code(code);
 
-        final Set<Tag> modelTags = new HashSet<>(moduleTags);
-        final Set<Code> modelCorequisites = new HashSet<>(moduleCorequisites);
-        return new Module(modelName, modelCredits, modelCode, modelTags, modelCorequisites);
+        // Check valid Name
+        if (name == null) {
+            String exceptionMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+            throw new IllegalValueException(exceptionMessage);
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        // Check valid Credits
+        if (credits == null) {
+            String exceptionMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Credits.class.getSimpleName());
+            throw new IllegalValueException(exceptionMessage);
+        }
+        if (!Credits.isValidCredits(credits)) {
+            throw new IllegalValueException(Credits.MESSAGE_CONSTRAINTS);
+        }
+        final Credits modelCredits = new Credits(credits);
+
+        // Check valid Semesters
+        if (semesters.isEmpty()) {
+            String exceptionMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Semester.class.getSimpleName());
+            throw new IllegalValueException(exceptionMessage);
+        }
+        final Set<Semester> modelSemesters = new HashSet<>();
+        for (JsonAdaptedSemester semester : semesters) {
+            modelSemesters.add(semester.toModelType());
+        }
+
+        // Check valid Corequisites
+        final Set<Code> modelCorequisites = new HashSet<>();
+        for (JsonAdaptedCode corequisite : corequisites) {
+            modelCorequisites.add(corequisite.toModelType());
+        }
+
+        // Check valid Tags
+        final Set<Tag> modelTags = new HashSet<>();
+        for (JsonAdaptedTag tag : tags) {
+            modelTags.add(tag.toModelType());
+        }
+
+        return new Module(modelCode, modelName, modelCredits, modelSemesters, modelCorequisites, modelTags);
     }
 
 }

--- a/src/main/java/pwe/planner/storage/JsonAdaptedSemester.java
+++ b/src/main/java/pwe/planner/storage/JsonAdaptedSemester.java
@@ -1,0 +1,54 @@
+package pwe.planner.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.model.planner.Semester;
+
+/**
+ * Jackson-friendly version of {@link Semester}.
+ */
+public class JsonAdaptedSemester {
+
+    private final String semesterValue;
+
+    /**
+     * Constructs a {@code JsonAdaptedCode} with the given {@code codeValue}.
+     */
+    @JsonCreator
+    public JsonAdaptedSemester(String semesterValue) {
+        requireNonNull(semesterValue);
+
+        this.semesterValue = semesterValue;
+    }
+
+    /**
+     * Converts a given {@code Semester} into this class for Jackson use.
+     */
+    public JsonAdaptedSemester(Semester source) {
+        requireNonNull(source);
+
+        semesterValue = source.plannerSemester;
+    }
+
+    @JsonValue
+    public String getSemesterValue() {
+        return semesterValue;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public Semester toModelType() throws IllegalValueException {
+        if (!Semester.isValidSemester(semesterValue)) {
+            throw new IllegalValueException(Semester.MESSAGE_SEMESTER_CONSTRAINTS);
+        }
+        return new Semester(semesterValue);
+    }
+
+}

--- a/src/main/java/pwe/planner/ui/ModuleCard.java
+++ b/src/main/java/pwe/planner/ui/ModuleCard.java
@@ -11,6 +11,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Module;
+import pwe.planner.model.planner.Semester;
 
 /**
  * An UI component that displays information of a {@code Module}.
@@ -31,13 +32,15 @@ public class ModuleCard extends UiPart<Region> {
     @FXML
     private HBox cardPane;
     @FXML
-    private Label name;
-    @FXML
     private Label id;
+    @FXML
+    private Label code;
+    @FXML
+    private Label name;
     @FXML
     private Label credits;
     @FXML
-    private Label code;
+    private Label semesters;
     @FXML
     private Label corequisites;
     @FXML
@@ -53,9 +56,15 @@ public class ModuleCard extends UiPart<Region> {
         credits.setText("Modular Credits: " + module.getCredits().value);
         code.setText(module.getCode().value);
 
+        String semestersText = module.getSemesters().stream().map(Semester::toString)
+                .collect(Collectors.joining(", "));
+        if (semestersText.length() == 0) {
+            semestersText = "None";
+        }
+        semesters.setText("Offered in Semesters: " + semestersText);
+
         String corequisitesText = module.getCorequisites().stream().map(Code::toString)
                 .collect(Collectors.joining(", "));
-
         if (corequisitesText.length() == 0) {
             corequisitesText = "None";
         }

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -29,6 +29,7 @@
       </HBox>
       <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       <Label fx:id="credits" styleClass="cell_small_label" text="\$credits" />
+      <Label fx:id="semesters" styleClass="cell_small_label" text="\$semesters" />
       <Label fx:id="corequisites" styleClass="cell_small_label" text="\$corequisites" />
       <FlowPane fx:id="tags" />
     </VBox>

--- a/src/test/data/JsonSerializableApplicationTest/duplicateModuleList.json
+++ b/src/test/data/JsonSerializableApplicationTest/duplicateModuleList.json
@@ -1,12 +1,14 @@
 {
   "modules": [ {
+    "code": "CS1010",
     "name": "Alice Pauline",
     "credits": "123",
-    "code": "CS1010",
+    "semesters": [ "1", "2", "4" ],
     "tagged": [ "friends" ]
   }, {
+    "code": "CS1010",
     "name": "Alice Pauline",
     "credits": "123",
-    "code": "CS1010"
+    "semesters": [ "1", "2", "4" ]
   } ]
 }

--- a/src/test/data/JsonSerializableApplicationTest/typicalModulesList.json
+++ b/src/test/data/JsonSerializableApplicationTest/typicalModulesList.json
@@ -1,46 +1,53 @@
 {
   "_comment": "Application save file which contains the same Module values as in TypicalModules#getTypicalApplication()",
   "modules" : [ {
+    "code" : "CS1010",
     "name" : "Alice Pauline",
     "credits" : "0",
-    "code" : "CS1010",
-    "tagged" : [ "friends" ],
-    "corequisites": [ ]
+    "semesters" : [ "1", "2", "4" ],
+    "corequisites": [ ],
+    "tagged" : [ "friends" ]
   }, {
+    "code" : "CS1231",
     "name" : "Benson Meier",
     "credits" : "1",
-    "code" : "CS1231",
-    "tagged" : [ "owesMoney", "friends" ],
-    "corequisites": [ "CS2102" ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ "CS2102" ],
+    "tagged" : [ "owesMoney", "friends" ]
   }, {
+    "code" : "CS2040C",
     "name" : "Carl Kurz",
     "credits" : "2",
-    "code" : "CS2040C",
-    "tagged" : [ ],
-    "corequisites": [ ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ ],
+    "tagged" : [ ]
   }, {
+    "code" : "CS2100",
     "name" : "Daniel Meier",
     "credits" : "3",
-    "code" : "CS2100",
-    "tagged" : [ "friends" ],
-    "corequisites": [ ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ ],
+    "tagged" : [ "friends" ]
   }, {
+    "code" : "CS2101",
     "name" : "Elle Meyer",
     "credits" : "4",
-    "code" : "CS2101",
-    "tagged" : [ ],
-    "corequisites": [ ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ ],
+    "tagged" : [ ]
   }, {
+    "code" : "CS2102",
     "name" : "Fiona Kunz",
     "credits" : "5",
-    "code" : "CS2102",
-    "tagged" : [ ],
-    "corequisites": [ "CS1231" ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ "CS1231" ],
+    "tagged" : [ ]
   }, {
+    "code" : "CS2105",
     "name" : "George Best",
     "credits" : "6",
-    "code" : "CS2105",
-    "tagged" : [ ],
-    "corequisites": [  ]
+    "semesters" : [ "1", "2" ],
+    "corequisites": [ ],
+    "tagged" : [ ]
   } ]
 }

--- a/src/test/java/pwe/planner/logic/LogicManagerTest.java
+++ b/src/test/java/pwe/planner/logic/LogicManagerTest.java
@@ -6,6 +6,7 @@ import static pwe.planner.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static pwe.planner.logic.commands.CommandTestUtil.CODE_DESC_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.CREDITS_DESC_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTERS_DESC_AMY;
 import static pwe.planner.testutil.TypicalModules.AMY;
 
 import java.io.IOException;
@@ -117,7 +118,9 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + CREDITS_DESC_AMY + CODE_DESC_AMY;
+        String addCommand = AddCommand.COMMAND_WORD + CODE_DESC_AMY + NAME_DESC_AMY + CREDITS_DESC_AMY
+                + SEMESTERS_DESC_AMY;
+
         Module expectedModule = new ModuleBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addModule(expectedModule);

--- a/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
@@ -3,8 +3,10 @@ package pwe.planner.logic.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
@@ -24,28 +26,46 @@ import pwe.planner.testutil.EditModuleDescriptorBuilder;
  * Contains helper methods for testing commands.
  */
 public class CommandTestUtil {
+    // Generic valid attributes
+    public static final String VALID_SEMESTER_ONE = "1";
+    public static final String VALID_SEMESTER_TWO = "2";
+    public static final String VALID_SEMESTER_THREE = "3";
+    public static final String VALID_SEMESTER_FOUR = "4";
+    public static final String VALID_TAG_HUSBAND = "husband";
+    public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_CODE_AMY = "AAA0000A";
+    public static final String VALID_CODE_BOB = "BBB1111B";
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
     public static final String VALID_CREDITS_AMY = "0";
     public static final String VALID_CREDITS_BOB = "999";
-    public static final String VALID_CODE_AMY = "AAA0000A";
-    public static final String VALID_CODE_BOB = "BBB1111B";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_SEMESTER_AMY_ONE = VALID_SEMESTER_ONE;
+    public static final String VALID_SEMESTER_AMY_TWO = VALID_SEMESTER_TWO;
+    public static final String VALID_SEMESTER_BOB_THREE = VALID_SEMESTER_THREE;
+    public static final String VALID_SEMESTER_BOB_FOUR = VALID_SEMESTER_FOUR;
 
+    public static final String CODE_DESC_AMY = " " + PREFIX_CODE + VALID_CODE_AMY;
+    public static final String CODE_DESC_BOB = " " + PREFIX_CODE + VALID_CODE_BOB;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String CREDITS_DESC_AMY = " " + PREFIX_CREDITS + VALID_CREDITS_AMY;
     public static final String CREDITS_DESC_BOB = " " + PREFIX_CREDITS + VALID_CREDITS_BOB;
-    public static final String CODE_DESC_AMY = " " + PREFIX_CODE + VALID_CODE_AMY;
-    public static final String CODE_DESC_BOB = " " + PREFIX_CODE + VALID_CODE_BOB;
+    public static final String SEMESTER_DESC_AMY_ONE = " " + PREFIX_SEMESTER + VALID_SEMESTER_AMY_ONE;
+    public static final String SEMESTER_DESC_AMY_TWO = " " + PREFIX_SEMESTER + VALID_SEMESTER_AMY_TWO;
+    public static final String SEMESTERS_DESC_AMY = SEMESTER_DESC_AMY_ONE + SEMESTER_DESC_AMY_TWO;
+    public static final String SEMESTER_DESC_BOB_THREE = " " + PREFIX_SEMESTER + VALID_SEMESTER_BOB_THREE;
+    public static final String SEMESTER_DESC_BOB_FOUR = " " + PREFIX_SEMESTER + VALID_SEMESTER_BOB_FOUR;
+    public static final String SEMESTERS_DESC_BOB = SEMESTER_DESC_BOB_THREE + SEMESTER_DESC_BOB_FOUR;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
+    public static final String INVALID_CODE_DESC = " " + PREFIX_CODE; // empty string not allowed for codes
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "Jame§"; // '§' not allowed in names
     public static final String INVALID_CREDITS_DESC = " " + PREFIX_CREDITS + "1a"; // 'a' not allowed in credits
-    public static final String INVALID_CODE_DESC = " " + PREFIX_CODE; // empty string not allowed for codes
+    public static final String INVALID_SEMESTER_DESC_ZERO = " " + PREFIX_SEMESTER + "0"; // 0 is out of range (1-4)
+    public static final String INVALID_SEMESTER_DESC_FIVE = " " + PREFIX_SEMESTER + "5"; // 5 is out of range (1-4)
+    public static final String INVALID_COREQUISITE_DESC = " " + PREFIX_COREQUISITE + "1000";
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
@@ -55,12 +75,21 @@ public class CommandTestUtil {
     public static final EditCommand.EditModuleDescriptor DESC_BOB;
 
     static {
-        DESC_AMY = new EditModuleDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withCredits(VALID_CREDITS_AMY).withCode(VALID_CODE_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
-        DESC_BOB = new EditModuleDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withCredits(VALID_CREDITS_BOB).withCode(VALID_CODE_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_AMY = new EditModuleDescriptorBuilder()
+                .withCode(VALID_CODE_AMY)
+                .withName(VALID_NAME_AMY)
+                .withCredits(VALID_CREDITS_AMY)
+                .withSemesters(VALID_SEMESTER_AMY_ONE, VALID_SEMESTER_AMY_TWO)
+                .withTags(VALID_TAG_FRIEND)
+                .build();
+
+        DESC_BOB = new EditModuleDescriptorBuilder()
+                .withName(VALID_NAME_BOB)
+                .withCredits(VALID_CREDITS_BOB)
+                .withCode(VALID_CODE_BOB)
+                .withSemesters(VALID_SEMESTER_BOB_THREE, VALID_SEMESTER_BOB_FOUR)
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+                .build();
     }
 
     /**
@@ -130,7 +159,7 @@ public class CommandTestUtil {
 
         Module module = model.getFilteredModuleList().get(targetIndex.getZeroBased());
         final String[] splitName = module.getName().fullName.split("\\s+");
-        model.updateFilteredModuleList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredModuleList().size());
     }

--- a/src/test/java/pwe/planner/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/AddCommandParserTest.java
@@ -8,16 +8,25 @@ import static pwe.planner.logic.commands.CommandTestUtil.CREDITS_DESC_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.INVALID_CODE_DESC;
 import static pwe.planner.logic.commands.CommandTestUtil.INVALID_CREDITS_DESC;
 import static pwe.planner.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static pwe.planner.logic.commands.CommandTestUtil.INVALID_SEMESTER_DESC_ZERO;
 import static pwe.planner.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static pwe.planner.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTERS_DESC_AMY;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTERS_DESC_BOB;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTER_DESC_BOB_FOUR;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTER_DESC_BOB_THREE;
 import static pwe.planner.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static pwe.planner.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_CODE_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_CREDITS_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_AMY_ONE;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_AMY_TWO;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_BOB_FOUR;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_BOB_THREE;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -32,6 +41,7 @@ import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 import pwe.planner.testutil.ModuleBuilder;
 
@@ -43,83 +53,119 @@ public class AddCommandParserTest {
         Module expectedModule =
                 new ModuleBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
 
+        String addCommand = PREAMBLE_WHITESPACE + CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_FRIEND;
         // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + CREDITS_DESC_BOB
-                + CODE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedModule));
-
-        // multiple names - last name accepted
-        assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + CREDITS_DESC_BOB
-                + CODE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedModule));
-
-        // multiple credits - last credits accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + CREDITS_DESC_AMY
-                + CREDITS_DESC_BOB + CODE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedModule));
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModule));
 
         // multiple codes - last code accepted
-        assertParseSuccess(parser, NAME_DESC_BOB + CREDITS_DESC_BOB
-                + CODE_DESC_AMY + CODE_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedModule));
+        addCommand = CODE_DESC_AMY + CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_FRIEND;
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModule));
+
+        // multiple names - last name accepted
+        addCommand = CODE_DESC_BOB + NAME_DESC_AMY + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_FRIEND;
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModule));
+
+        // multiple credits - last credits accepted
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_AMY + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_FRIEND;
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModule));
+
+        // multiple semesters - all accepted
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_AMY + CREDITS_DESC_BOB + SEMESTERS_DESC_AMY
+                + SEMESTERS_DESC_BOB;
+        Module expectedModuleMultipleSemesters = new ModuleBuilder(BOB)
+                .withSemesters(VALID_SEMESTER_AMY_ONE, VALID_SEMESTER_AMY_TWO, VALID_SEMESTER_BOB_THREE,
+                        VALID_SEMESTER_BOB_FOUR)
+                .withTags()
+                .build();
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModuleMultipleSemesters));
 
         // multiple tags - all accepted
-        Module expectedModuleMultipleTags =
-                new ModuleBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
-        assertParseSuccess(parser, NAME_DESC_BOB + CREDITS_DESC_BOB + CODE_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedModuleMultipleTags));
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_AMY + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_FRIEND + TAG_DESC_HUSBAND;
+        Module expectedModuleMultipleTags = new ModuleBuilder(BOB)
+                .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND).build();
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModuleMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Module expectedModule = new ModuleBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + CREDITS_DESC_AMY
-                + CODE_DESC_AMY, new AddCommand(expectedModule));
+        String addCommand = CODE_DESC_AMY + NAME_DESC_AMY + CREDITS_DESC_AMY + SEMESTERS_DESC_AMY;
+        assertParseSuccess(parser, addCommand, new AddCommand(expectedModule));
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
+        // missing code prefix
+        String addCommand = VALID_CODE_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB;
+        assertParseFailure(parser, addCommand, expectedMessage);
+
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + CREDITS_DESC_BOB
-                + CODE_DESC_BOB, expectedMessage);
+        addCommand = VALID_NAME_BOB + CODE_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB;
+        assertParseFailure(parser, addCommand, expectedMessage);
 
         // missing credits prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_CREDITS_BOB
-                + CODE_DESC_BOB, expectedMessage);
+        addCommand = VALID_CREDITS_BOB + CODE_DESC_BOB + NAME_DESC_BOB + SEMESTERS_DESC_BOB;
+        assertParseFailure(parser, addCommand, expectedMessage);
 
-        // missing code prefix
-        assertParseFailure(parser, NAME_DESC_BOB + CREDITS_DESC_BOB
-                + VALID_CODE_BOB, expectedMessage);
+        // missing semester prefix for first of the two semesters
+        addCommand = VALID_SEMESTER_BOB_THREE + CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB
+                + SEMESTER_DESC_BOB_FOUR;
+        assertParseFailure(parser, addCommand, expectedMessage);
+
+        // missing semester prefix for last of the two semesters
+        addCommand = VALID_SEMESTER_BOB_FOUR + CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB
+                + SEMESTER_DESC_BOB_THREE;
+        assertParseFailure(parser, addCommand, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB
-                + VALID_CREDITS_BOB + VALID_CODE_BOB, expectedMessage);
+        addCommand = VALID_CODE_BOB + VALID_NAME_BOB + VALID_CREDITS_BOB + VALID_SEMESTER_BOB_THREE
+                + VALID_SEMESTER_BOB_FOUR;
+        assertParseFailure(parser, addCommand, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
+        // invalid code
+        String addCommand = INVALID_CODE_DESC + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Code.MESSAGE_CONSTRAINTS);
+
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + CREDITS_DESC_BOB + CODE_DESC_BOB + TAG_DESC_HUSBAND
-                + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+        addCommand = CODE_DESC_BOB + INVALID_NAME_DESC + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Name.MESSAGE_CONSTRAINTS);
 
         // invalid credits
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_CREDITS_DESC + CODE_DESC_BOB + TAG_DESC_HUSBAND
-                + TAG_DESC_FRIEND, Credits.MESSAGE_CONSTRAINTS);
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + INVALID_CREDITS_DESC + SEMESTERS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Credits.MESSAGE_CONSTRAINTS);
 
-        // invalid code
-        assertParseFailure(parser, NAME_DESC_BOB + CREDITS_DESC_BOB + INVALID_CODE_DESC + TAG_DESC_HUSBAND
-                + TAG_DESC_FRIEND, Code.MESSAGE_CONSTRAINTS);
+        // invalid semesters
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + INVALID_SEMESTER_DESC_ZERO
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Semester.MESSAGE_SEMESTER_CONSTRAINTS);
 
         // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + CREDITS_DESC_BOB + CODE_DESC_BOB + INVALID_TAG_DESC
-                + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+        addCommand = CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + INVALID_TAG_DESC + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + CREDITS_DESC_BOB + INVALID_CODE_DESC,
-                Code.MESSAGE_CONSTRAINTS);
+        addCommand = INVALID_CODE_DESC + INVALID_NAME_DESC + INVALID_CREDITS_DESC + SEMESTERS_DESC_BOB
+                + INVALID_TAG_DESC + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, Code.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + CREDITS_DESC_BOB + CODE_DESC_BOB
-                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        addCommand = PREAMBLE_NON_EMPTY + CODE_DESC_BOB + NAME_DESC_BOB + CREDITS_DESC_BOB + SEMESTERS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND;
+        assertParseFailure(parser, addCommand, String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/pwe/planner/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/EditCommandParserTest.java
@@ -91,8 +91,8 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_CODE_DESC + VALID_CODE_AMY + VALID_CREDITS_AMY,
-                Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_CODE_DESC + INVALID_NAME_DESC + VALID_CODE_AMY + VALID_CREDITS_AMY,
+                Code.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/pwe/planner/storage/JsonAdaptedModuleTest.java
+++ b/src/test/java/pwe/planner/storage/JsonAdaptedModuleTest.java
@@ -7,6 +7,7 @@ import static pwe.planner.testutil.TypicalModules.BENSON;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 
@@ -14,21 +15,33 @@ import pwe.planner.commons.exceptions.IllegalValueException;
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.testutil.Assert;
 
 public class JsonAdaptedModuleTest {
-    private static final String INVALID_NAME = "Rächel";
-    private static final String INVALID_CREDITS = "+651234";
-    private static final String INVALID_CODE = " ";
-    private static final String INVALID_TAG = "#friend";
-
+    private static final String VALID_CODE = BENSON.getCode().toString();
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_CREDITS = BENSON.getCredits().toString();
-    private static final String VALID_CODE = BENSON.getCode().toString();
+    private static final List<JsonAdaptedSemester> VALID_SEMESTERS = BENSON.getSemesters().stream()
+            .map(JsonAdaptedSemester::new).collect(Collectors.toList());
+    private static final List<JsonAdaptedCode> VALID_COREQUISITES = BENSON.getCorequisites().stream()
+            .map(JsonAdaptedCode::new).collect(Collectors.toList());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedCode> VALID_COREQUISITES = new ArrayList<>();
+
+    private static final String INVALID_CODE = "A1234B";
+    private static final String INVALID_NAME = "Näme containing invalid characters";
+    private static final String INVALID_CREDITS = "1000";
+    private static final JsonAdaptedSemester INVALID_SEMESTER = new JsonAdaptedSemester("5");
+    private static final List<JsonAdaptedSemester> INVALID_SEMESTERS = Stream
+            .concat(VALID_SEMESTERS.stream(), List.of(INVALID_SEMESTER).stream())
+            .collect(Collectors.toList());
+    private static final JsonAdaptedCode INVALID_COREQUISITE = new JsonAdaptedCode("Z9876Y");
+    private static final List<JsonAdaptedCode> INVALID_COREQUISITES = Stream
+            .concat(VALID_COREQUISITES.stream(), List.of(INVALID_COREQUISITE).stream())
+            .collect(Collectors.toList());
+    private static final String INVALID_TAG = "#hashIsInvalid";
 
     @Test
     public void toModelType_validModuleDetails_returnsModule() throws Exception {
@@ -37,49 +50,83 @@ public class JsonAdaptedModuleTest {
     }
 
     @Test
-    public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(INVALID_NAME, VALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
-        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
-        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(null, VALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
-        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
-    }
-
-    @Test
-    public void toModelType_invalidCredits_throwsIllegalValueException() {
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, INVALID_CREDITS, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
-        String expectedMessage = Credits.MESSAGE_CONSTRAINTS;
-        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullCredits_throwsIllegalValueException() {
-        JsonAdaptedModule module = new JsonAdaptedModule(VALID_NAME, null, VALID_CODE, VALID_TAGS, VALID_COREQUISITES);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Credits.class.getSimpleName());
-        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
-    }
-
-    @Test
     public void toModelType_invalidCode_throwsIllegalValueException() {
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, INVALID_CODE, VALID_TAGS, VALID_COREQUISITES);
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                INVALID_CODE, VALID_NAME, VALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
         String expectedMessage = Code.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
 
     @Test
     public void toModelType_nullCode_throwsIllegalValueException() {
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, null, VALID_TAGS, VALID_COREQUISITES);
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                null, VALID_NAME, VALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Code.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidName_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, INVALID_NAME, VALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = Name.MESSAGE_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullName_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, null, VALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidCredits_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, INVALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = Credits.MESSAGE_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullCredits_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, null, VALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Credits.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidSemesters_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, VALID_CREDITS, INVALID_SEMESTERS, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = Semester.MESSAGE_SEMESTER_CONSTRAINTS;
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullSemesters_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, VALID_CREDITS, null, VALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Semester.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidCorequisites_throwsIllegalValueException() {
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, VALID_CREDITS, VALID_SEMESTERS, INVALID_COREQUISITES, VALID_TAGS
+        );
+        String expectedMessage = Code.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, module::toModelType);
     }
 
@@ -87,9 +134,9 @@ public class JsonAdaptedModuleTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedModule module =
-                new JsonAdaptedModule(VALID_NAME, VALID_CREDITS, VALID_CODE, invalidTags, VALID_COREQUISITES);
+        JsonAdaptedModule module = new JsonAdaptedModule(
+                VALID_CODE, VALID_NAME, VALID_CREDITS, VALID_SEMESTERS, VALID_COREQUISITES, invalidTags
+        );
         Assert.assertThrows(IllegalValueException.class, module::toModelType);
     }
-
 }

--- a/src/test/java/pwe/planner/testutil/EditModuleDescriptorBuilder.java
+++ b/src/test/java/pwe/planner/testutil/EditModuleDescriptorBuilder.java
@@ -10,6 +10,7 @@ import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
 /**
@@ -32,10 +33,20 @@ public class EditModuleDescriptorBuilder {
      */
     public EditModuleDescriptorBuilder(Module module) {
         descriptor = new EditCommand.EditModuleDescriptor();
+        descriptor.setCode(module.getCode());
         descriptor.setName(module.getName());
         descriptor.setCredits(module.getCredits());
-        descriptor.setCode(module.getCode());
+        descriptor.setSemesters(module.getSemesters());
+        descriptor.setCorequisites(module.getCorequisites());
         descriptor.setTags(module.getTags());
+    }
+
+    /**
+     * Sets the {@code Code} of the {@code EditModuleDescriptor} that we are building.
+     */
+    public EditModuleDescriptorBuilder withCode(String code) {
+        descriptor.setCode(new Code(code));
+        return this;
     }
 
     /**
@@ -55,20 +66,12 @@ public class EditModuleDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code Code} of the {@code EditModuleDescriptor} that we are building.
-     */
-    public EditModuleDescriptorBuilder withCode(String code) {
-        descriptor.setCode(new Code(code));
-        return this;
-    }
-
-    /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditModuleDescriptor}
+     * Parses the {@code semesters} into a {@code Set<Semester>} and set it to the {@code EditModuleDescriptor}
      * that we are building.
      */
-    public EditModuleDescriptorBuilder withTags(String... tags) {
-        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
-        descriptor.setTags(tagSet);
+    public EditModuleDescriptorBuilder withSemesters(String... semesters) {
+        Set<Semester> semesterSet = Stream.of(semesters).map(Semester::new).collect(Collectors.toSet());
+        descriptor.setSemesters(semesterSet);
         return this;
     }
 
@@ -79,6 +82,16 @@ public class EditModuleDescriptorBuilder {
     public EditModuleDescriptorBuilder withCorequisites(String... corequisites) {
         Set<Code> corequisitesSet = Stream.of(corequisites).map(Code::new).collect(Collectors.toSet());
         descriptor.setCorequisites(corequisitesSet);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code EditModuleDescriptor}
+     * that we are building.
+     */
+    public EditModuleDescriptorBuilder withTags(String... tags) {
+        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTags(tagSet);
         return this;
     }
 

--- a/src/test/java/pwe/planner/testutil/ModuleBuilder.java
+++ b/src/test/java/pwe/planner/testutil/ModuleBuilder.java
@@ -1,12 +1,17 @@
 package pwe.planner.testutil;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 import pwe.planner.model.util.SampleDataUtil;
 
@@ -18,30 +23,45 @@ public class ModuleBuilder {
     public static final String DEFAULT_NAME = "Alice Pauline";
     public static final String DEFAULT_CREDITS = "666";
     public static final String DEFAULT_CODE = "ABC1234Z";
+    public static final String DEFAULT_SEMESTERS_ONE = "1";
+    public static final String DEFAULT_SEMESTERS_TWO = "2";
 
+    private Code code;
     private Name name;
     private Credits credits;
-    private Code code;
-    private Set<Tag> tags;
     private Set<Code> corequisites;
+    private Set<Semester> semesters;
+    private Set<Tag> tags;
 
     public ModuleBuilder() {
+        code = new Code(DEFAULT_CODE);
         name = new Name(DEFAULT_NAME);
         credits = new Credits(DEFAULT_CREDITS);
-        code = new Code(DEFAULT_CODE);
-        tags = new HashSet<>();
+        semesters = new HashSet<>();
+        semesters.add(new Semester(DEFAULT_SEMESTERS_ONE));
+        semesters.add(new Semester(DEFAULT_SEMESTERS_TWO));
         corequisites = new HashSet<>();
+        tags = new HashSet<>();
     }
 
     /**
      * Initializes the ModuleBuilder with the data of {@code moduleToCopy}.
      */
     public ModuleBuilder(Module moduleToCopy) {
+        code = moduleToCopy.getCode();
         name = moduleToCopy.getName();
         credits = moduleToCopy.getCredits();
-        code = moduleToCopy.getCode();
-        tags = new HashSet<>(moduleToCopy.getTags());
+        semesters = new HashSet<>(moduleToCopy.getSemesters());
         corequisites = new HashSet<>(moduleToCopy.getCorequisites());
+        tags = new HashSet<>(moduleToCopy.getTags());
+    }
+
+    /**
+     * Sets the {@code Code} of the {@code Module} that we are building.
+     */
+    public ModuleBuilder withCode(String code) {
+        this.code = new Code(code);
+        return this;
     }
 
     /**
@@ -53,10 +73,10 @@ public class ModuleBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Module} that we are building.
+     * Sets the {@code Credits} of the {@code Module} that we are building.
      */
-    public ModuleBuilder withTags(String... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
+    public ModuleBuilder withCredits(String credits) {
+        this.credits = new Credits(credits);
         return this;
     }
 
@@ -77,23 +97,33 @@ public class ModuleBuilder {
     }
 
     /**
-     * Sets the {@code Code} of the {@code Module} that we are building.
+     * Parses the {@code semesters} into a {@code Set<Semester>} and set it to the {@code Module} that we are building.
      */
-    public ModuleBuilder withCode(String code) {
-        this.code = new Code(code);
+    public ModuleBuilder withSemesters(String... semesters) {
+        requireNonNull(semesters);
+
+        this.semesters = Arrays.stream(semesters).map(Semester::new).collect(Collectors.toSet());
         return this;
     }
 
     /**
-     * Sets the {@code Credits} of the {@code Module} that we are building.
+     * Sets the {@code semesters} of the {@code Module} that we are building.
      */
-    public ModuleBuilder withCredits(String credits) {
-        this.credits = new Credits(credits);
+    public ModuleBuilder withSemesters(Set<Semester> semesters) {
+        this.semesters = new HashSet<>(semesters);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Module} that we are building.
+     */
+    public ModuleBuilder withTags(String... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
         return this;
     }
 
     public Module build() {
-        return new Module(name, credits, code, tags, corequisites);
+        return new Module(code, name, credits, semesters, corequisites, tags);
     }
 
 }

--- a/src/test/java/pwe/planner/testutil/ModuleUtil.java
+++ b/src/test/java/pwe/planner/testutil/ModuleUtil.java
@@ -1,15 +1,19 @@
 package pwe.planner.testutil;
 
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_COREQUISITE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
 import pwe.planner.logic.commands.AddCommand;
 import pwe.planner.logic.commands.EditCommand.EditModuleDescriptor;
+import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Module;
+import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
 /**
@@ -29,12 +33,12 @@ public class ModuleUtil {
      */
     public static String getModuleDetails(Module module) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_NAME + module.getName().fullName + " ");
-        sb.append(PREFIX_CREDITS + module.getCredits().value + " ");
-        sb.append(PREFIX_CODE + module.getCode().value + " ");
-        module.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
-        );
+        sb.append(PREFIX_CODE + module.getCode().value + " ")
+                .append(PREFIX_NAME + module.getName().fullName + " ")
+                .append(PREFIX_CREDITS + module.getCredits().value + " ");
+        module.getSemesters().stream().forEach(s -> sb.append(PREFIX_SEMESTER + s.plannerSemester + " "));
+        module.getCorequisites().stream().forEach(s -> sb.append(PREFIX_COREQUISITE + s.value + " "));
+        module.getTags().stream().forEach(s -> sb.append(PREFIX_TAG + s.tagName + " "));
         return sb.toString();
     }
 
@@ -43,15 +47,31 @@ public class ModuleUtil {
      */
     public static String getEditModuleDescriptorDetails(EditModuleDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
-        descriptor.getCredits().ifPresent(credits -> sb.append(PREFIX_CREDITS).append(credits.value).append(" "));
-        descriptor.getCode().ifPresent(code -> sb.append(PREFIX_CODE).append(code.value).append(" "));
+        descriptor.getCode().ifPresent(code -> sb.append(PREFIX_CODE).append(code.value).append(' '));
+        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(' '));
+        descriptor.getCredits().ifPresent(credits -> sb.append(PREFIX_CREDITS).append(credits.value).append(' '));
+        if (descriptor.getSemesters().isPresent()) {
+            Set<Semester> semesters = descriptor.getSemesters().get();
+            if (semesters.isEmpty()) {
+                sb.append(PREFIX_SEMESTER).append(' ');
+            } else {
+                semesters.forEach(s -> sb.append(PREFIX_SEMESTER).append(s.plannerSemester).append(' '));
+            }
+        }
+        if (descriptor.getCorequisites().isPresent()) {
+            Set<Code> corequisites = descriptor.getCorequisites().get();
+            if (corequisites.isEmpty()) {
+                sb.append(PREFIX_COREQUISITE).append(' ');
+            } else {
+                corequisites.forEach(s -> sb.append(PREFIX_COREQUISITE).append(s.value).append(' '));
+            }
+        }
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(' ');
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(' '));
             }
         }
         return sb.toString();

--- a/src/test/java/pwe/planner/testutil/TypicalModules.java
+++ b/src/test/java/pwe/planner/testutil/TypicalModules.java
@@ -6,6 +6,10 @@ import static pwe.planner.logic.commands.CommandTestUtil.VALID_CREDITS_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_CREDITS_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_AMY_ONE;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_AMY_TWO;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_BOB_FOUR;
+import static pwe.planner.logic.commands.CommandTestUtil.VALID_SEMESTER_BOB_THREE;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
@@ -23,38 +27,90 @@ import pwe.planner.model.module.Module;
  */
 public class TypicalModules {
 
-    public static final Module ALICE = new ModuleBuilder().withName("Alice Pauline")
+    public static final Module ALICE = new ModuleBuilder()
             .withCode("CS1010")
+            .withName("Alice Pauline")
             .withCredits("0")
-            .withTags("friends").build();
-    public static final Module BENSON = new ModuleBuilder().withName("Benson Meier")
-            .withCode("CS1231")
-            .withCredits("1")
-            .withTags("owesMoney", "friends")
-            .withCorequisites("CS2102")
+            .withSemesters("1", "2", "4")
+            .withTags("friends")
             .build();
-    public static final Module CARL = new ModuleBuilder().withName("Carl Kurz").withCredits("2")
-            .withCode("CS2040C").build();
-    public static final Module DANIEL = new ModuleBuilder().withName("Daniel Meier").withCredits("3")
-            .withCode("CS2100").withTags("friends").build();
-    public static final Module ELLE = new ModuleBuilder().withName("Elle Meyer").withCredits("4")
-            .withCode("CS2101").build();
-    public static final Module FIONA = new ModuleBuilder().withName("Fiona Kunz").withCredits("5")
-            .withCode("CS2102").withCorequisites("CS1231").build();
-    public static final Module GEORGE = new ModuleBuilder().withName("George Best").withCredits("6")
-            .withCode("CS2105").build();
+
+    public static final Module BENSON = new ModuleBuilder()
+            .withCode("CS1231")
+            .withName("Benson Meier")
+            .withCredits("1")
+            .withSemesters("1", "2")
+            .withCorequisites("CS2102")
+            .withTags("owesMoney", "friends")
+            .build();
+
+    public static final Module CARL = new ModuleBuilder()
+            .withCode("CS2040C")
+            .withName("Carl Kurz")
+            .withCredits("2")
+            .withSemesters("1", "2")
+            .build();
+
+    public static final Module DANIEL = new ModuleBuilder()
+            .withCode("CS2100")
+            .withName("Daniel Meier")
+            .withCredits("3")
+            .withSemesters("1", "2")
+            .withTags("friends")
+            .build();
+
+    public static final Module ELLE = new ModuleBuilder()
+            .withCode("CS2101")
+            .withName("Elle Meyer")
+            .withCredits("4")
+            .withSemesters("1", "2")
+            .build();
+
+    public static final Module FIONA = new ModuleBuilder()
+            .withCode("CS2102")
+            .withName("Fiona Kunz")
+            .withCredits("5")
+            .withSemesters("1", "2")
+            .withCorequisites("CS1231")
+            .build();
+
+    public static final Module GEORGE = new ModuleBuilder()
+            .withCode("CS2105")
+            .withName("George Best")
+            .withCredits("6")
+            .withSemesters("1", "2")
+            .build();
 
     // Manually added
-    public static final Module HOON = new ModuleBuilder().withName("Hoon Meier").withCredits("7")
-            .withCode("CS2106").build();
-    public static final Module IDA = new ModuleBuilder().withName("Ida Mueller").withCredits("8")
-            .withCode("CS2107").build();
+    public static final Module HOON = new ModuleBuilder()
+            .withName("Hoon Meier")
+            .withCredits("7")
+            .withCode("CS2106")
+            .withSemesters("3")
+            .build();
+
+    public static final Module IDA = new ModuleBuilder()
+            .withName("Ida Mueller")
+            .withCredits("8")
+            .withCode("CS2107")
+            .withSemesters("4")
+            .build();
 
     // Manually added - Module's details found in {@code CommandTestUtil}
-    public static final Module AMY = new ModuleBuilder().withName(VALID_NAME_AMY).withCredits(VALID_CREDITS_AMY)
-            .withCode(VALID_CODE_AMY).withTags(VALID_TAG_FRIEND).build();
-    public static final Module BOB = new ModuleBuilder().withName(VALID_NAME_BOB).withCredits(VALID_CREDITS_BOB)
-            .withCode(VALID_CODE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+    public static final Module AMY = new ModuleBuilder()
+            .withCode(VALID_CODE_AMY)
+            .withName(VALID_NAME_AMY)
+            .withCredits(VALID_CREDITS_AMY)
+            .withSemesters(VALID_SEMESTER_AMY_ONE, VALID_SEMESTER_AMY_TWO)
+            .withTags(VALID_TAG_FRIEND)
+            .build();
+
+    public static final Module BOB = new ModuleBuilder()
+            .withCode(VALID_CODE_BOB)
+            .withName(VALID_NAME_BOB)
+            .withCredits(VALID_CREDITS_BOB)
+            .withSemesters(VALID_SEMESTER_BOB_THREE, VALID_SEMESTER_BOB_FOUR)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = PREFIX_NAME + "Meier"; // A keyword that matches MEIER

--- a/src/test/java/pwe/planner/ui/ModuleListPanelTest.java
+++ b/src/test/java/pwe/planner/ui/ModuleListPanelTest.java
@@ -9,6 +9,7 @@ import static pwe.planner.ui.testutil.GuiTestAssert.assertCardDisplaysModule;
 import static pwe.planner.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import java.util.Collections;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -21,6 +22,8 @@ import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.planner.Semester;
+import pwe.planner.model.tag.Tag;
 
 public class ModuleListPanelTest extends GuiUnitTest {
     private static final ObservableList<Module> TYPICAL_MODULES = FXCollections.observableList(getTypicalModules());
@@ -80,7 +83,10 @@ public class ModuleListPanelTest extends GuiUnitTest {
             Name name = new Name(i + "a");
             Credits credits = new Credits("999");
             Code code = new Code("CS1010");
-            Module module = new Module(name, credits, code, Collections.emptySet(), Collections.emptySet());
+            Set<Code> corequisites = Collections.emptySet();
+            Set<Semester> semesters = Collections.emptySet();
+            Set<Tag> tags = Collections.emptySet();
+            Module module = new Module(code, name, credits, semesters, corequisites, tags);
             backingList.add(module);
         }
         return backingList;

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -15,6 +15,8 @@ import static pwe.planner.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static pwe.planner.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static pwe.planner.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static pwe.planner.logic.commands.CommandTestUtil.NAME_DESC_BOB;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTERS_DESC_AMY;
+import static pwe.planner.logic.commands.CommandTestUtil.SEMESTERS_DESC_BOB;
 import static pwe.planner.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static pwe.planner.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static pwe.planner.logic.commands.CommandTestUtil.VALID_CODE_BOB;
@@ -56,7 +58,7 @@ public class EditCommandSystemTest extends ApplicationSystemTest {
          */
         Index index = INDEX_FIRST_MODULE;
         String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + NAME_DESC_BOB + "  "
-                + CREDITS_DESC_BOB + " " + CODE_DESC_BOB + " " + TAG_DESC_HUSBAND + " ";
+                + CREDITS_DESC_BOB + " " + CODE_DESC_BOB + " " + SEMESTERS_DESC_BOB + "  " + TAG_DESC_HUSBAND + " ";
         Module editedModule = new ModuleBuilder(BOB).withTags(VALID_TAG_HUSBAND).build();
         assertCommandSuccess(command, index, editedModule);
 
@@ -133,7 +135,7 @@ public class EditCommandSystemTest extends ApplicationSystemTest {
         index = INDEX_FIRST_MODULE;
         selectModule(index);
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + NAME_DESC_AMY + CREDITS_DESC_AMY
-                + CODE_DESC_AMY + TAG_DESC_FRIEND;
+                + CODE_DESC_AMY + TAG_DESC_FRIEND + SEMESTERS_DESC_AMY;
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new module's name
         assertCommandSuccess(command, index, AMY, index);


### PR DESCRIPTION
Resolves #90.

Users may want to keep track of what modules are offered in an academic
year.

For instance, CS1010 Programming methodology is offered in Semesters
1, 2, 4 (Special Semester Term 2) only. It would be pointless for users
to plan to take the module in Special Semester Term 1 (Semester 3 in our
application) when it is not actually being offered.

Let's implement `Module#semesters` to enable users to keep track of
which semesters a `Module` can be taken, and update the UI to show the 
semesters the module is offered in.

Lastly, let's update the unit and system tests.

* [1/2] [Model/module: add `Module#semesters`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/200/commits/d7b023320a875346ef81b618b311f7b88ec3155c)
* [2/2] [test: fix unit and system tests to support `Module#semesters`](https://github.com/CS2113-AY1819S2-T09-1/main/pull/200/commits/836eae1b7c7dee761f1a37a1e31b2e08dacb42f0)