### PR TITLE
build.gradle: update `defaultTasks` and add more compiler checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,4 +242,10 @@ compileJava {
     options.compilerArgs += [ "-Xlint:cast,deprecation,divzero,rawtypes,unchecked" ]
 }
 
-defaultTasks 'clean', 'headless', 'allTests', 'coverage', 'asciidoctor'
+compileTestJava {
+    options.warnings = true
+    options.deprecation = true
+    options.compilerArgs += [ "-Xlint:cast,deprecation,divzero,rawtypes,unchecked" ]
+}
+
+defaultTasks 'clean', 'checkstyleMain', 'checkstyleTest', 'headless', 'allTests', 'coverage', 'asciidoctor'


### PR DESCRIPTION
Gradle supplies compiler arguments when compiling Java source code.
However, Gradle does not supply compiler arguments when compiling Java
test code.

Besides that, the `defaultTasks` does not check for Checkstyle errors.

Let's update `build.gradle` to address these two issues by:
* adding `compileTestJava`
* updating `defaultTasks` to include `checkstyleMain` & `checkstyleTest`