### PR TITLE
Model/requirement: make 'name' input case-insensitive

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
@@ -69,7 +69,7 @@ public class RequirementAddCommand extends Command {
         }
 
         if (currentRequirementCategory.hasModuleCode(toAdd)) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_CODE, toFind));
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_CODE, currentRequirementCategory.getName()));
         }
 
         Stream<RequirementCategory> requirementCategories = model.getApplication()
@@ -86,10 +86,11 @@ public class RequirementAddCommand extends Command {
         newCodeSet.addAll(toAdd);
 
         RequirementCategory editedRequirementCategory = new RequirementCategory(
-                toFind, currentRequirementCategory.getCredits(), newCodeSet);
+                currentRequirementCategory.getName(), currentRequirementCategory.getCredits(), newCodeSet
+        );
         model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         model.commitApplication();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toFind));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, currentRequirementCategory.getName()));
     }
 
     @Override

--- a/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
@@ -66,17 +66,19 @@ public class RequirementRemoveCommand extends Command {
         }
 
         if (!currentRequirementCategory.getCodeSet().containsAll(toRemove)) {
-            throw new CommandException(String.format(MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE, toFind));
+            throw new CommandException(String.format(MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE,
+                    currentRequirementCategory.getName()));
         }
 
         Set<Code> newCodeSet = new HashSet<>(currentRequirementCategory.getCodeSet());
         newCodeSet.removeAll(toRemove);
 
-        RequirementCategory editedRequirementCategory =
-                new RequirementCategory(toFind, currentRequirementCategory.getCredits(), newCodeSet);
+        RequirementCategory editedRequirementCategory = new RequirementCategory(
+                currentRequirementCategory.getName(), currentRequirementCategory.getCredits(), newCodeSet
+        );
         model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         model.commitApplication();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toFind));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, currentRequirementCategory.getName()));
     }
 
     @Override

--- a/src/main/java/pwe/planner/logic/parser/RequirementAddCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/RequirementAddCommandParser.java
@@ -18,7 +18,7 @@ import pwe.planner.model.module.Name;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class RequirementAddCommandParser {
+public class RequirementAddCommandParser implements Parser<RequirementAddCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.

--- a/src/main/java/pwe/planner/model/requirement/UniqueRequirementCategoryList.java
+++ b/src/main/java/pwe/planner/model/requirement/UniqueRequirementCategoryList.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.model.module.Name;
 import pwe.planner.model.requirement.exceptions.DuplicateRequirementCategoryException;
 import pwe.planner.model.requirement.exceptions.RequirementCategoryNotFoundException;
@@ -60,7 +61,8 @@ public class UniqueRequirementCategoryList implements Iterable<RequirementCatego
         requireNonNull(toCheck);
 
         return internalList.stream()
-                .filter(requirementCategory -> requirementCategory.getName().equals(toCheck))
+                .filter(requirementCategory -> StringUtil
+                        .compareEqualsIgnoreCase(requirementCategory.getName().toString(), toCheck.toString()))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
@@ -1,6 +1,9 @@
 package pwe.planner.logic.commands;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static pwe.planner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
 import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
 import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
@@ -20,28 +23,33 @@ import pwe.planner.model.ModelManager;
 import pwe.planner.model.UserPrefs;
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Name;
+import pwe.planner.model.requirement.RequirementCategory;
 import pwe.planner.storage.JsonSerializableApplication;
 
 public class RequirementAddCommandTest {
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private CommandHistory commandHistory = new CommandHistory();
     private Model model;
     private Set<Code> codeList = new HashSet<>();
 
-    @Before public void setUp() throws IllegalValueException {
+    @Before
+    public void setUp() throws IllegalValueException {
         model = new ModelManager(
                 new JsonSerializableApplication(getTypicalModuleList(), getTypicalDegreePlannerList(),
                         getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
     }
 
-    @Test public void constructor_nullModule_throwsNullPointerException() {
+    @Test
+    public void constructor_nullModule_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
         new RequirementAddCommand(null, null);
     }
 
-    @Test public void execute_nonExistentRequirementCategory_throwsCommandException() {
+    @Test
+    public void execute_nonExistentRequirementCategory_throwsCommandException() {
         codeList.clear();
         Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
         assertCommandFailure(new RequirementAddCommand(nonExistentRequirementCategoryName, codeList),
@@ -49,21 +57,121 @@ public class RequirementAddCommandTest {
                         nonExistentRequirementCategoryName));
     }
 
-    @Test public void execute_nonExistentCode_throwsCommandException() {
+    @Test
+    public void execute_nonExistentCode_throwsCommandException() {
         codeList.clear();
         codeList.add(new Code("CS2010"));
         Name requirementCategoryName = new Name("Computing Foundation");
         assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
                 RequirementAddCommand.MESSAGE_NONEXISTENT_CODE);
+
+        //case insensitive checks
+        requirementCategoryName = new Name("comPUTING FOUNDATion");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_CODE,
+                        requirementCategoryName));
     }
 
-    @Test public void execute_duplicateCode_throwsCommandException() {
+    @Test
+    public void execute_duplicateCode_throwsCommandException() {
         codeList.clear();
         codeList.add(new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Foundation");
         assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
                 String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
                         requirementCategoryName));
+
+        //case insensitive checks
+        Name requirementCategoryNameInsensitive = new Name("COMPUting FOundAtIon");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryNameInsensitive, codeList), model,
+                commandHistory, String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
+                        requirementCategoryName));
+    }
+
+    @Test
+    public void execute_existingCode_throwsCommandException() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Breadth");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                RequirementAddCommand.MESSAGE_EXISTING_CODE);
+
+        //case insensitive checks
+        requirementCategoryName = new Name("COMPUting BREAdth");
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_EXISTING_CODE,
+                        requirementCategoryName));
+    }
+
+    @Test
+    public void execute_addModuleToRequirementCategory_success() {
+        codeList.clear();
+        Name requirementCategoryName = new Name("Computing Foundation");
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+
+        Model expectedModel = model;
+        expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
+                expectedModel);
+
+        // undo -> reverts application back to previous state
+        expectedModel.undoApplication();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // redo -> reverts application back to previous state before undo
+        expectedModel.redoApplication();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_addModuleToRequirementCategoryCaseInsensitive_success() {
+        codeList.clear();
+        Name requirementCategoryName = new Name("CoMpUtInG BreaDTH");
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+
+        Model expectedModel = model;
+        expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
+                expectedModel);
+
+    }
+
+    @Test
+    public void execute_equals() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("Computing Foundation");
+
+        Set<Code> codeListToCompare = new HashSet<>();
+        codeListToCompare.add(new Code("CS1010"));
+        Name requirementCategoryNameToCompare = new Name("Mathematics");
+
+        RequirementAddCommand commandBaseline = new RequirementAddCommand(requirementCategoryName, codeList);
+        RequirementAddCommand commandToCompare =
+                new RequirementAddCommand(requirementCategoryNameToCompare, codeListToCompare);
+
+        //same object -> returns true
+        assertTrue(commandBaseline.equals(commandBaseline));
+
+        //different objects, same values -> returns true
+        RequirementAddCommand commandBaselineCopy = new RequirementAddCommand(requirementCategoryName, codeList);
+        assertTrue(commandBaseline.equals(commandBaselineCopy));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(commandToCompare));
+
+        //different objects -> returns false
+        assertFalse(commandBaseline.equals(1));
     }
 
 }

--- a/src/test/java/pwe/planner/logic/commands/RequirementRemoveCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementRemoveCommandTest.java
@@ -64,6 +64,11 @@ public class RequirementRemoveCommandTest {
         Name requirementCategoryName = new Name("Computing Foundation");
         assertCommandFailure(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
                 RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE);
+
+        //case insensitive checks
+        requirementCategoryName = new Name("comPUTING FOUNDATion");
+        assertCommandFailure(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
+                RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE);
     }
 
     @Test
@@ -74,13 +79,45 @@ public class RequirementRemoveCommandTest {
         assertCommandFailure(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE,
                         requirementCategoryName));
+
+        //case insensitive checks
+        Name requirementCategoryNameInsensitive = new Name("COMPUting FOundAtIon");
+        assertCommandFailure(new RequirementRemoveCommand(requirementCategoryNameInsensitive, codeList), model,
+                commandHistory, String.format(RequirementRemoveCommand.MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE,
+                        requirementCategoryName));
     }
 
     @Test
-    public void execute_addModuleToRequirementCategory_success() {
+    public void execute_removeModuleToRequirementCategory_success() {
         codeList.clear();
         codeList.add(new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Foundation");
+        RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+
+        Model expectedModel = model;
+        expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new RequirementRemoveCommand(requirementCategoryName, codeList), model, commandHistory,
+                String.format(RequirementRemoveCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
+                expectedModel);
+
+        // undo -> reverts application back to previous state
+        expectedModel.undoApplication();
+        assertCommandSuccess(new UndoCommand(), model, commandHistory, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // redo -> reverts application back to previous state before undo
+        expectedModel.redoApplication();
+        assertCommandSuccess(new RedoCommand(), model, commandHistory, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_removeModuleToRequirementCategoryCaseInsensitive_success() {
+        codeList.clear();
+        codeList.add(new Code("CS2100"));
+        Name requirementCategoryName = new Name("COMPUting FOundAtIon");
         RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
         RequirementCategory editedRequirementCategory =
                 new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -32,6 +32,7 @@ import pwe.planner.logic.commands.ListCommand;
 import pwe.planner.logic.commands.PlannerListAllCommand;
 import pwe.planner.logic.commands.PlannerMoveCommand;
 import pwe.planner.logic.commands.RedoCommand;
+import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.logic.commands.SelectCommand;
@@ -141,6 +142,16 @@ public class CommandParserTest {
                 PlannerMoveCommand.COMMAND_WORD + " " + PREFIX_YEAR + "1 " + PREFIX_SEMESTER + "2 " + PREFIX_CODE
                         + "CS1010");
         assertEquals(new PlannerMoveCommand(new Year("1"), new Semester("2"), new Code("CS1010")), command);
+    }
+
+    @Test
+    public void parseCommand_requirementAdd() throws Exception {
+        Name name = new Name("Computing Foundation");
+        Set<Code> codeSet = new HashSet<>();
+        codeSet.add(new Code("CS1010"));
+        RequirementAddCommand command = (RequirementAddCommand)
+                parser.parseCommand(RequirementUtil.getRequirementAddCommand(name, codeSet));
+        assertEquals(new RequirementAddCommand(name, codeSet), command);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/RequirementAddCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/RequirementAddCommandParserTest.java
@@ -1,0 +1,71 @@
+package pwe.planner.logic.parser;
+
+import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import pwe.planner.logic.commands.RequirementAddCommand;
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Name;
+
+public class RequirementAddCommandParserTest {
+
+    private RequirementAddCommandParser parser = new RequirementAddCommandParser();
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid format
+        assertParseFailure(parser, " INVALID INPUT", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RequirementAddCommand.MESSAGE_USAGE));
+
+        // invalid name format
+        assertParseFailure(parser, " " + PREFIX_NAME + "  " + PREFIX_CODE + "CS1010 ",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // invalid code format
+        assertParseFailure(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "1231",
+                Code.MESSAGE_CONSTRAINTS);
+
+        // invalid name and code format
+        assertParseFailure(parser, " " + PREFIX_NAME + "   " + PREFIX_CODE + "1231",
+                Name.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1231",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RequirementAddCommand.MESSAGE_USAGE));
+
+    }
+
+    @Test
+    public void parse_validArgs_returnsRequirementAddCommand() {
+        Name validName = new Name("Computing Foundation");
+        Set<Code> validCodeSet = new HashSet<>();
+        validCodeSet.add(new Code("CS1010"));
+
+        RequirementAddCommand expectedRequirementAddCommand =
+                new RequirementAddCommand(validName, validCodeSet);
+
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementAddCommand);
+
+        // whitespace only preamble
+        assertParseSuccess(parser,
+                PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementAddCommand);
+
+        // multiple requirement categories specified - last requirement category accepted
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Mathematics " + PREFIX_NAME
+                + "Computing Foundation " + PREFIX_CODE + "CS1010", expectedRequirementAddCommand);
+
+    }
+}

--- a/src/test/java/pwe/planner/testutil/RequirementUtil.java
+++ b/src/test/java/pwe/planner/testutil/RequirementUtil.java
@@ -5,6 +5,7 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.Set;
 
+import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Name;
@@ -20,6 +21,18 @@ public class RequirementUtil {
     public static String getRequirementRemoveCommand(Name requirementCategoryName, Set<Code> codeSet) {
         StringBuilder sb = new StringBuilder();
         sb.append(RequirementRemoveCommand.COMMAND_WORD).append(" ");
+        sb.append(PREFIX_NAME).append(requirementCategoryName.toString()).append(" ");
+        codeSet.stream().forEach(s -> sb.append(PREFIX_CODE).append(s.value).append(" "));
+        return sb.toString();
+    }
+
+
+    /**
+     * Returns an add command string for adding the {@code code}.
+     */
+    public static String getRequirementAddCommand(Name requirementCategoryName, Set<Code> codeSet) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(RequirementAddCommand.COMMAND_WORD).append(" ");
         sb.append(PREFIX_NAME).append(requirementCategoryName.toString()).append(" ");
         codeSet.stream().forEach(s -> sb.append(PREFIX_CODE).append(s.value).append(" "));
         return sb.toString();


### PR DESCRIPTION
Resolves #163 

Our application allows users to add and remove modules to the specified
requirement category. However, when entering the command, the `name` 
of the requirement category is case-sensitive and users have to specify the 
name as shown on the user interface.

This makes it difficult for users as they have to ensure an exact match before
the application accepts the input.

To address these issues, let's enhance the requirement commands to make
then case-insensitive