### PR TITLE
Logic: refactor XYZContainsKeywordsPredicate keyword to `String`

### DIFF
--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -67,13 +67,13 @@ public class BooleanExpressionParser<T> {
         KeywordsPredicate<T> predicate = null;
         if (prefixes.contains(PREFIX_NAME) && argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String nameKeyword = parseName(argMultimap.getValue(PREFIX_NAME).get()).toString();
-            predicate = new NameContainsKeywordsPredicate<T>(List.of(nameKeyword));
+            predicate = new NameContainsKeywordsPredicate<>(nameKeyword);
         } else if (prefixes.contains(PREFIX_CODE) && argMultimap.getValue(PREFIX_CODE).isPresent()) {
             String codeKeyword = parseCode(argMultimap.getValue(PREFIX_CODE).get()).toString();
-            predicate = new CodeContainsKeywordsPredicate<T>(List.of(codeKeyword));
+            predicate = new CodeContainsKeywordsPredicate<>(codeKeyword);
         } else if (prefixes.contains(PREFIX_CREDITS) && argMultimap.getValue(PREFIX_CREDITS).isPresent()) {
             String creditKeyword = parseCredits(argMultimap.getValue(PREFIX_CREDITS).get()).toString();
-            predicate = new CreditsContainsKeywordsPredicate<T>(List.of(creditKeyword));
+            predicate = new CreditsContainsKeywordsPredicate<>(creditKeyword);
         } else if (prefixes.contains(PREFIX_YEAR) && argMultimap.getValue(PREFIX_YEAR).isPresent()) {
             String yearKeyword = parseYear(argMultimap.getValue(PREFIX_YEAR).get()).toString();
             predicate = new YearContainsKeywordPredicate<>(yearKeyword);

--- a/src/main/java/pwe/planner/model/module/CodeContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/CodeContainsKeywordsPredicate.java
@@ -3,18 +3,16 @@ package pwe.planner.model.module;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
 
-import java.util.List;
-
 /**
- * Tests that a {@code Module}'s {@code Code} matches any of the keywords given.
+ * Tests that a {@code Module}'s {@code Code} matches the keyword given.
  */
 public class CodeContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
-    private final List<String> keywords;
+    private final String keyword;
 
-    public CodeContainsKeywordsPredicate(List<String> keywords) {
-        requireNonNull(keywords);
+    public CodeContainsKeywordsPredicate(String keyword) {
+        requireNonNull(keyword);
 
-        this.keywords = keywords;
+        this.keyword = keyword;
     }
 
     @Override
@@ -23,14 +21,14 @@ public class CodeContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
         Module module = (Module) object;
 
         String moduleCode = module.getCode().toString();
-        return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleCode));
+        return parseKeyword(keyword, moduleCode);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof CodeContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((CodeContainsKeywordsPredicate) other).keywords)); // state check
+                && keyword.equals(((CodeContainsKeywordsPredicate) other).keyword)); // state check
     }
 
 }

--- a/src/main/java/pwe/planner/model/module/CreditsContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/CreditsContainsKeywordsPredicate.java
@@ -3,18 +3,16 @@ package pwe.planner.model.module;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
 
-import java.util.List;
-
 /**
- * Tests that a {@code Module}'s {@code Credit} matches any of the keywords given.
+ * Tests that a {@code Module}'s {@code Credit} matches keyword given.
  */
 public class CreditsContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
-    private final List<String> keywords;
+    private final String keyword;
 
-    public CreditsContainsKeywordsPredicate(List<String> keywords) {
-        requireNonNull(keywords);
+    public CreditsContainsKeywordsPredicate(String keyword) {
+        requireNonNull(keyword);
 
-        this.keywords = keywords;
+        this.keyword = keyword;
     }
 
     @Override
@@ -23,14 +21,14 @@ public class CreditsContainsKeywordsPredicate<T> implements KeywordsPredicate<T>
         Module module = (Module) object;
 
         String moduleCredits = module.getCredits().toString();
-        return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleCredits));
+        return parseKeyword(keyword, moduleCredits);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof CreditsContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((CreditsContainsKeywordsPredicate) other).keywords)); // state check
+                && keyword.equals(((CreditsContainsKeywordsPredicate) other).keyword)); // state check
     }
 
 }

--- a/src/main/java/pwe/planner/model/module/NameContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/NameContainsKeywordsPredicate.java
@@ -3,18 +3,16 @@ package pwe.planner.model.module;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
 
-import java.util.List;
-
 /**
- * Tests that a {@code Module}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Module}'s {@code Name} matches the keyword given.
  */
 public class NameContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
-    private final List<String> keywords;
+    private final String keyword;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
-        requireNonNull(keywords);
+    public NameContainsKeywordsPredicate(String keyword) {
+        requireNonNull(keyword);
 
-        this.keywords = keywords;
+        this.keyword = keyword;
     }
 
     @Override
@@ -23,14 +21,14 @@ public class NameContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
         Module module = (Module) object;
 
         String moduleName = module.getName().toString();
-        return keywords.stream().anyMatch(keyword -> parseKeyword(keyword, moduleName));
+        return parseKeyword(keyword, moduleName);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+                && keyword.equals(((NameContainsKeywordsPredicate) other).keyword)); // state check
     }
 
 }

--- a/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
@@ -10,7 +10,6 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import pwe.planner.commons.core.index.Index;
@@ -159,7 +158,7 @@ public class CommandTestUtil {
 
         Module module = model.getFilteredModuleList().get(targetIndex.getZeroBased());
         final String[] splitName = module.getName().fullName.split("\\s+");
-        model.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(Arrays.asList(splitName[0])));
+        model.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(splitName[0]));
 
         assertEquals(1, model.getFilteredModuleList().size());
     }

--- a/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
@@ -12,8 +12,8 @@ import static pwe.planner.testutil.TypicalModules.FIONA;
 import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
 import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -46,9 +46,9 @@ public class FindCommandTest {
     @Test
     public void equals() {
         NameContainsKeywordsPredicate<Module> firstPredicate =
-                new NameContainsKeywordsPredicate<>(Collections.singletonList("first"));
+                new NameContainsKeywordsPredicate<>("first");
         NameContainsKeywordsPredicate<Module> secondPredicate =
-                new NameContainsKeywordsPredicate<>(Collections.singletonList("second"));
+                new NameContainsKeywordsPredicate<>("second");
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -71,9 +71,9 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noModuleFound() {
+    public void execute_oneKeywords_noModuleFound() {
         String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate(" ");
+        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate("doNotExist");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
@@ -81,56 +81,56 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleNameKeywords_multipleModulesFound() {
-        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate("Kurz Elle Kunz");
+    public void execute_nameKeyword_foundModule() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate<Module> predicate = prepareNamePredicate("Kurz ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredModuleList());
+        assertEquals(List.of(CARL), model.getFilteredModuleList());
     }
 
     @Test
-    public void execute_multipleCodeKeywords_multipleModulesFound() {
-        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
+    public void execute_codeKeyword_foundModule() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
         // TODO: update the module code after TypicalModule attribute are updated
-        CodeContainsKeywordsPredicate<Module> predicate = prepareCodePredicate("CS2040C CS2101 CS2102");
+        CodeContainsKeywordsPredicate<Module> predicate = prepareCodePredicate(" CS2101 ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredModuleList());
+        assertEquals(List.of(ELLE), model.getFilteredModuleList());
     }
 
     @Test
-    public void execute_multipleCreditsKeywords_multipleModulesFound() {
-        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
+    public void execute_creditKeyword_foundModule() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
         // TODO: update the module credits after TypicalModule attribute are updated
-        CreditsContainsKeywordsPredicate<Module> predicate = prepareCreditsPredicate("2 4 5");
+        CreditsContainsKeywordsPredicate<Module> predicate = prepareCreditsPredicate("5");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredModuleList());
+        assertEquals(List.of(FIONA), model.getFilteredModuleList());
     }
 
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate<Module> prepareNamePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate<>(userInput);
     }
 
     /**
      * Parses {@code userInput} into a {@code CodeContainsKeywordsPredicate}.
      */
     private CodeContainsKeywordsPredicate<Module> prepareCodePredicate(String userInput) {
-        return new CodeContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
+        return new CodeContainsKeywordsPredicate<>(userInput);
     }
 
     /**
      * Parses {@code userInput} into a {@code CreditsContainsKeywordsPredicate}.
      */
     private CreditsContainsKeywordsPredicate<Module> prepareCreditsPredicate(String userInput) {
-        return new CreditsContainsKeywordsPredicate<>(Arrays.asList(userInput.split("\\s+")));
+        return new CreditsContainsKeywordsPredicate<>(userInput);
     }
 
 }

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -10,8 +10,6 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
 import static pwe.planner.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Rule;
@@ -102,10 +100,10 @@ public class CommandParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo");
+        String keyword = "foo";
         FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " "
                 + PREFIX_NAME + "foo");
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate<>(keywords)), command);
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate<>(keyword)), command);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
@@ -13,8 +13,6 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-
 import org.junit.Test;
 
 import pwe.planner.logic.commands.FindCommand;
@@ -46,17 +44,17 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindNameCommand =
-                new FindCommand(new NameContainsKeywordsPredicate<>(Arrays.asList("Alice")));
+                new FindCommand(new NameContainsKeywordsPredicate<>("Alice"));
         // single keyword
         assertParseSuccess(parser, PREFIX_NAME + "Alice", expectedFindNameCommand);
 
         FindCommand expectedFindCodeCommand =
-                new FindCommand(new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1231")));
+                new FindCommand(new CodeContainsKeywordsPredicate<>("CS1231"));
         // single keyword
         assertParseSuccess(parser, PREFIX_CODE + "CS1231", expectedFindCodeCommand);
 
         FindCommand expectedFindCreditsCommand =
-                new FindCommand(new CreditsContainsKeywordsPredicate<>(Arrays.asList("999")));
+                new FindCommand(new CreditsContainsKeywordsPredicate<>("999"));
         // single keyword
         assertParseSuccess(parser, PREFIX_CREDITS + "999", expectedFindCreditsCommand);
     }

--- a/src/test/java/pwe/planner/model/ModelManagerTest.java
+++ b/src/test/java/pwe/planner/model/ModelManagerTest.java
@@ -180,8 +180,8 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentApplication, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(Arrays.asList(keywords)));
+        String keyword = ALICE.getName().toString();
+        modelManager.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(keyword));
 
         assertFalse(modelManager
                 .equals(new ModelManager(application, userPrefs)));

--- a/src/test/java/pwe/planner/model/module/CodeContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/CodeContainsKeywordsPredicateTest.java
@@ -3,10 +3,6 @@ package pwe.planner.model.module;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Test;
 
 import pwe.planner.testutil.ModuleBuilder;
@@ -14,20 +10,20 @@ import pwe.planner.testutil.ModuleBuilder;
 public class CodeContainsKeywordsPredicateTest {
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "second";
 
         CodeContainsKeywordsPredicate<Module> firstPredicate =
-                new CodeContainsKeywordsPredicate<>(firstPredicateKeywordList);
+                new CodeContainsKeywordsPredicate<>(firstPredicateKeyword);
         CodeContainsKeywordsPredicate<Module> secondPredicate =
-                new CodeContainsKeywordsPredicate<>(secondPredicateKeywordList);
+                new CodeContainsKeywordsPredicate<>(secondPredicateKeyword);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
         CodeContainsKeywordsPredicate<Module> firstPredicateCopy =
-                new CodeContainsKeywordsPredicate<>(firstPredicateKeywordList);
+                new CodeContainsKeywordsPredicate<>(firstPredicateKeyword);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -44,32 +40,22 @@ public class CodeContainsKeywordsPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
         CodeContainsKeywordsPredicate<Module> predicate =
-                new CodeContainsKeywordsPredicate<>(Collections.singletonList("CS1010"));
+                new CodeContainsKeywordsPredicate<>("CS1010");
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
-
-        // Multiple keywords
-        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1010", "CS1231"));
-        assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
-        assertTrue(predicate.test(new ModuleBuilder().withCode("CS1231").build()));
 
         // Mixed-case keywords
-        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("cS1010", "Cs1231"));
+        predicate = new CodeContainsKeywordsPredicate<>("cS1010");
         assertTrue(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
-        assertTrue(predicate.test(new ModuleBuilder().withCode("CS1231").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        CodeContainsKeywordsPredicate<Module> predicate = new CodeContainsKeywordsPredicate<>(Collections.emptyList());
-        assertFalse(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
-
         // Non-matching keyword
-        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS1000"));
+        CodeContainsKeywordsPredicate<Module> predicate = new CodeContainsKeywordsPredicate<>("CS1000");
         assertFalse(predicate.test(new ModuleBuilder().withCode("CS1010").build()));
 
         // Keywords match credits and name, but does not match code
-        predicate = new CodeContainsKeywordsPredicate<>(Arrays.asList("CS0000", "CS1111"));
+        predicate = new CodeContainsKeywordsPredicate<>("CS0000");
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }

--- a/src/test/java/pwe/planner/model/module/CreditsContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/CreditsContainsKeywordsPredicateTest.java
@@ -3,10 +3,6 @@ package pwe.planner.model.module;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Test;
 
 import pwe.planner.testutil.ModuleBuilder;
@@ -15,20 +11,20 @@ public class CreditsContainsKeywordsPredicateTest {
     //TODO: to update all test cases again after regex for `Credits` is updated
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("1 2");
-        List<String> secondPredicateKeywordList = Arrays.asList("1", "1");
+        String firstPredicateKeyword = "1";
+        String secondPredicateKeyword = "2";
 
         CreditsContainsKeywordsPredicate<Module> firstPredicate =
-                new CreditsContainsKeywordsPredicate<>(firstPredicateKeywordList);
+                new CreditsContainsKeywordsPredicate<>(firstPredicateKeyword);
         CreditsContainsKeywordsPredicate<Module> secondPredicate =
-                new CreditsContainsKeywordsPredicate<>(secondPredicateKeywordList);
+                new CreditsContainsKeywordsPredicate<>(secondPredicateKeyword);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
         CreditsContainsKeywordsPredicate<Module> firstPredicateCopy =
-                new CreditsContainsKeywordsPredicate<>(firstPredicateKeywordList);
+                new CreditsContainsKeywordsPredicate<>(firstPredicateKeyword);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -45,27 +41,14 @@ public class CreditsContainsKeywordsPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
         CreditsContainsKeywordsPredicate<Module> predicate =
-                new CreditsContainsKeywordsPredicate<>(Collections.singletonList("444"));
-        assertTrue(predicate.test(new ModuleBuilder().withCredits("444").build()));
-
-        // Multiple keywords
-        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("122", "444"));
-        assertTrue(predicate.test(new ModuleBuilder().withCredits("122").build()));
-
-        // Only one matching keyword
-        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("999", "444"));
+                new CreditsContainsKeywordsPredicate<>("444");
         assertTrue(predicate.test(new ModuleBuilder().withCredits("444").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        CreditsContainsKeywordsPredicate<Module> predicate = new CreditsContainsKeywordsPredicate<>(
-                Collections.emptyList());
-        assertFalse(predicate.test(new ModuleBuilder().withCredits("123").build()));
-
         // Non-matching keyword
-        predicate = new CreditsContainsKeywordsPredicate<>(Arrays.asList("144"));
+        CreditsContainsKeywordsPredicate<Module> predicate = new CreditsContainsKeywordsPredicate<>("144");
         assertFalse(predicate.test(new ModuleBuilder().withCredits("441").build()));
     }
 }

--- a/src/test/java/pwe/planner/model/module/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/NameContainsKeywordsPredicateTest.java
@@ -3,10 +3,6 @@ package pwe.planner.model.module;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Test;
 
 import pwe.planner.testutil.ModuleBuilder;
@@ -15,20 +11,20 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList("first");
-        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "second";
 
         NameContainsKeywordsPredicate<Module> firstPredicate = new NameContainsKeywordsPredicate<>(
-                firstPredicateKeywordList);
+                firstPredicateKeyword);
         NameContainsKeywordsPredicate<Module> secondPredicate = new NameContainsKeywordsPredicate<>(
-                secondPredicateKeywordList);
+                secondPredicateKeyword);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
         NameContainsKeywordsPredicate<Module> firstPredicateCopy = new NameContainsKeywordsPredicate<>(
-                firstPredicateKeywordList);
+                firstPredicateKeyword);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -45,35 +41,30 @@ public class NameContainsKeywordsPredicateTest {
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
         NameContainsKeywordsPredicate<Module> predicate = new NameContainsKeywordsPredicate<>(
-                Collections.singletonList("Alice"));
+                "Alice");
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
-        // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Alice", "Bob"));
+        // exact keyword match
+        predicate = new NameContainsKeywordsPredicate<>("Alice Bob");
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
-        // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new ModuleBuilder().withName("Alice Carol").build()));
+        // exact mixed case keyword
+        predicate = new NameContainsKeywordsPredicate<>("AlIcE bOb");
+        assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
-        // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("aLIce", "bOB"));
+        // Mixed-case keyword
+        predicate = new NameContainsKeywordsPredicate<>("aLIce");
         assertTrue(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        NameContainsKeywordsPredicate<Module> predicate = new NameContainsKeywordsPredicate<>(
-                Collections.emptyList());
-        assertFalse(predicate.test(new ModuleBuilder().withName("Alice").build()));
-
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("Carol"));
+        NameContainsKeywordsPredicate<Module> predicate = new NameContainsKeywordsPredicate<>("Carol");
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice Bob").build()));
 
-        // Keywords match credits and code, but does not match name
-        predicate = new NameContainsKeywordsPredicate<>(Arrays.asList("12345", "Main", "Street"));
+        // Keywords match credits, but does not match name
+        predicate = new NameContainsKeywordsPredicate<>("123");
         assertFalse(predicate.test(new ModuleBuilder().withName("Alice").withCredits("123")
                 .withCode("CS1010").build()));
     }


### PR DESCRIPTION
The `find` command allows only one keyword per prefix, it does not make
sense for our predicate keywords to be a `List<String>`

Let's refactor all our XYZContainsKeywordsPredicate keyword to be
`String` and:
* cascade all changes to all affected class
* fix all broken unit tests
* remove irrelevant unit tests

In addition, let's add some unit tests to ensure that the predicate class is 
working as intended.