### PR TITLE
Test:Planner: add the tests for `DegreePlanner` related model classes

### DIFF
--- a/src/test/java/pwe/planner/model/planner/DegreePlannerTest.java
+++ b/src/test/java/pwe/planner/model/planner/DegreePlannerTest.java
@@ -1,0 +1,78 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_1;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_2;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import pwe.planner.testutil.DegreePlannerBuilder;
+
+public class DegreePlannerTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        DegreePlanner degreePlanner = new DegreePlannerBuilder().build();
+        thrown.expect(UnsupportedOperationException.class);
+        degreePlanner.getCodes().remove(0);
+    }
+
+    @Test
+    public void isSameDegreePlanner() {
+        // same object -> returns true
+        assertTrue(YEAR_1_SEMESTER_1.isSameDegreePlanner(YEAR_1_SEMESTER_1));
+
+        // null -> returns false
+        assertFalse(YEAR_1_SEMESTER_1.isSameDegreePlanner(null));
+
+        // different year and code -> returns false
+        DegreePlanner editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1)
+                .withYear("2").withCodes("CS1111", "CS2222").build();
+        assertFalse(YEAR_1_SEMESTER_1.isSameDegreePlanner(editedDegreePlanner));
+
+        // different year but same code -> returns false
+        editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withYear("2").build();
+        assertFalse(YEAR_1_SEMESTER_1.isSameDegreePlanner(editedDegreePlanner));
+
+        // different year but same semester -> returns false
+        editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withYear("2").withSemester("1").build();
+        assertFalse(YEAR_1_SEMESTER_1.isSameDegreePlanner(editedDegreePlanner));
+
+        // same year, same semester, different codes -> returns true
+        editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withCodes("CS1111", "CS2222").build();
+        assertTrue(YEAR_1_SEMESTER_1.isSameDegreePlanner(editedDegreePlanner));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        DegreePlanner degreePlannerCopy = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).build();
+        assertTrue(YEAR_1_SEMESTER_1.equals(degreePlannerCopy));
+
+        // same object -> returns true
+        assertTrue(YEAR_1_SEMESTER_1.equals(YEAR_1_SEMESTER_1));
+
+        // different type -> returns false
+        assertFalse(YEAR_1_SEMESTER_1.equals(5));
+
+        // different degree plan -> returns false
+        assertFalse(YEAR_1_SEMESTER_1.equals(YEAR_1_SEMESTER_2));
+
+        // different year -> returns false
+        DegreePlanner editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withYear("2").build();
+        assertFalse(YEAR_1_SEMESTER_1.equals(editedDegreePlanner));
+
+        // different semester -> returns false
+        editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withSemester("2").build();
+        assertFalse(YEAR_1_SEMESTER_1.equals(editedDegreePlanner));
+
+        // different codes -> returns false
+        editedDegreePlanner = new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withCodes("CS1111", "CS2222").build();
+        assertFalse(YEAR_1_SEMESTER_1.equals(editedDegreePlanner));
+    }
+}

--- a/src/test/java/pwe/planner/model/planner/SemesterTest.java
+++ b/src/test/java/pwe/planner/model/planner/SemesterTest.java
@@ -1,0 +1,40 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import pwe.planner.testutil.Assert;
+
+public class SemesterTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new Semester(null));
+    }
+
+    @Test
+    public void constructor_invalidSemester_throwsIllegalArgumentException() {
+        String invalidSemester = "";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Semester(invalidSemester));
+    }
+
+    @Test
+    public void isValidSemester() {
+        // null year
+        Assert.assertThrows(NullPointerException.class, () -> Semester.isValidSemester(null));
+
+        // invalid year
+        assertFalse(Semester.isValidSemester("")); // empty string
+        assertFalse(Semester.isValidSemester(" ")); // spaces only
+        assertFalse(Semester.isValidSemester("+1")); // no plus sign
+        assertFalse(Semester.isValidSemester("-1")); // no negative sign
+        assertFalse(Semester.isValidSemester("5")); // no integer outside range of 1 to 4
+        assertFalse(Semester.isValidSemester("01")); // no leading zero
+        assertFalse(Semester.isValidSemester("one")); // alphabets
+        assertFalse(Semester.isValidSemester("1 6")); // spaces within digits
+
+        // valid year
+        assertTrue(Semester.isValidSemester("1")); // exactly zero
+    }
+}

--- a/src/test/java/pwe/planner/model/planner/UniqueDegreePlannerListTest.java
+++ b/src/test/java/pwe/planner/model/planner/UniqueDegreePlannerListTest.java
@@ -1,0 +1,181 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_1;
+import static pwe.planner.testutil.TypicalDegreePlanners.YEAR_1_SEMESTER_2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import pwe.planner.model.planner.exceptions.DegreePlannerNotFoundException;
+import pwe.planner.model.planner.exceptions.DuplicateDegreePlannerException;
+import pwe.planner.testutil.DegreePlannerBuilder;
+
+public class UniqueDegreePlannerListTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final UniqueDegreePlannerList uniqueDegreePlannerList = new UniqueDegreePlannerList();
+
+    @Test
+    public void contains_nullDegreePlanner_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.contains(null);
+    }
+
+    @Test
+    public void getDegreePlannerByCode_nullCode_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.getDegreePlannerByCode(null);
+    }
+
+    @Test
+    public void contains_degreePlannerNotInList_returnsFalse() {
+        assertFalse(uniqueDegreePlannerList.contains(YEAR_1_SEMESTER_1));
+    }
+
+    @Test
+    public void contains_degreePlannerInList_returnsTrue() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        assertTrue(uniqueDegreePlannerList.contains(YEAR_1_SEMESTER_1));
+    }
+
+    @Test
+    public void add_nullDegreePlanner_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.add(null);
+    }
+
+    @Test
+    public void add_duplicateDegreePlanner_throwsDuplicateDegreePlannerException() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        thrown.expect(DuplicateDegreePlannerException.class);
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+    }
+
+    @Test
+    public void setDegreePlanner_nullTargetDegreePlanner_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.setDegreePlanner(null, YEAR_1_SEMESTER_1);
+    }
+
+    @Test
+    public void setDegreePlanner_nullEditedDegreePlanner_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, null);
+    }
+
+    @Test
+    public void setDegreePlanner_targetDegreePlannerNotInList_throwsDegreePlannerNotFoundException() {
+        thrown.expect(DegreePlannerNotFoundException.class);
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_1);
+    }
+
+    @Test
+    public void setDegreePlanner_editedDegreePlannerIsSameDegreePlanner_success() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_1);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        expectedUniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanner_editedDegreePlannerHasSameIdentity_success() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        DegreePlanner editedDegreePlanner =
+                new DegreePlannerBuilder(YEAR_1_SEMESTER_1).withCodes("CS1111", "CS2222").build();
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, editedDegreePlanner);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        expectedUniqueDegreePlannerList.add(editedDegreePlanner);
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanner_editedDegreePlannerHasDifferentIdentity_success() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_2);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        expectedUniqueDegreePlannerList.add(YEAR_1_SEMESTER_2);
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanner_editedDegreePlannerHasNonUniqueIdentity_throwsDuplicateDegreePlannerException() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_2);
+        thrown.expect(DuplicateDegreePlannerException.class);
+        uniqueDegreePlannerList.setDegreePlanner(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_2);
+    }
+
+    @Test
+    public void remove_nullDegreePlanner_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.remove(null);
+    }
+
+    @Test
+    public void remove_degreePlannerDoesNotExist_throwsDegreePlannerNotFoundException() {
+        thrown.expect(DegreePlannerNotFoundException.class);
+        uniqueDegreePlannerList.remove(YEAR_1_SEMESTER_1);
+    }
+
+    @Test
+    public void remove_existingDegreePlanner_removesDegreePlanner() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        uniqueDegreePlannerList.remove(YEAR_1_SEMESTER_1);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanners_nullUniqueDegreePlannerList_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.setDegreePlanners((UniqueDegreePlannerList) null);
+    }
+
+    @Test
+    public void setDegreePlanners_uniqueDegreePlannerList_replacesOwnListWithProvidedUniqueDegreePlannerList() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        expectedUniqueDegreePlannerList.add(YEAR_1_SEMESTER_2);
+        uniqueDegreePlannerList.setDegreePlanners(expectedUniqueDegreePlannerList);
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanners_nullList_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueDegreePlannerList.setDegreePlanners((List<DegreePlanner>) null);
+    }
+
+    @Test
+    public void setDegreePlanners_list_replacesOwnListWithProvidedList() {
+        uniqueDegreePlannerList.add(YEAR_1_SEMESTER_1);
+        List<DegreePlanner> degreePlannerList = Collections.singletonList(YEAR_1_SEMESTER_2);
+        uniqueDegreePlannerList.setDegreePlanners(degreePlannerList);
+        UniqueDegreePlannerList expectedUniqueDegreePlannerList = new UniqueDegreePlannerList();
+        expectedUniqueDegreePlannerList.add(YEAR_1_SEMESTER_2);
+        assertEquals(expectedUniqueDegreePlannerList, uniqueDegreePlannerList);
+    }
+
+    @Test
+    public void setDegreePlanners_listWithDuplicateDegreePlanners_throwsDuplicateDegreePlannerException() {
+        List<DegreePlanner> listWithDuplicateDegreePlanners = Arrays.asList(YEAR_1_SEMESTER_1, YEAR_1_SEMESTER_1);
+        thrown.expect(DuplicateDegreePlannerException.class);
+        uniqueDegreePlannerList.setDegreePlanners(listWithDuplicateDegreePlanners);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        thrown.expect(UnsupportedOperationException.class);
+        uniqueDegreePlannerList.asUnmodifiableObservableList().remove(0);
+    }
+}

--- a/src/test/java/pwe/planner/model/planner/YearTest.java
+++ b/src/test/java/pwe/planner/model/planner/YearTest.java
@@ -1,0 +1,40 @@
+package pwe.planner.model.planner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import pwe.planner.testutil.Assert;
+
+public class YearTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> new Year(null));
+    }
+
+    @Test
+    public void constructor_invalidYear_throwsIllegalArgumentException() {
+        String invalidYear = "";
+        Assert.assertThrows(IllegalArgumentException.class, () -> new Year(invalidYear));
+    }
+
+    @Test
+    public void isValidYear() {
+        // null year
+        Assert.assertThrows(NullPointerException.class, () -> Year.isValidYear(null));
+
+        // invalid year
+        assertFalse(Year.isValidYear("")); // empty string
+        assertFalse(Year.isValidYear(" ")); // spaces only
+        assertFalse(Year.isValidYear("+1")); // no plus sign
+        assertFalse(Year.isValidYear("-1")); // no negative sign
+        assertFalse(Year.isValidYear("5")); // no integer outside range of 1 to 4
+        assertFalse(Year.isValidYear("01")); // no leading zero
+        assertFalse(Year.isValidYear("one")); // alphabets
+        assertFalse(Year.isValidYear("1 6")); // spaces within digits
+
+        // valid year
+        assertTrue(Year.isValidYear("1")); // exactly zero
+    }
+}


### PR DESCRIPTION
Currently, there is no tests for `DegreePlanner`, `Semester`, `Year`
and `UniqueDegreePlannerList` classes.   

Let's add the abovementioned classes to cover different test cases.