### PR TITLE
Model/module: make `Code` store uppercase string

### DIFF
--- a/src/main/java/pwe/planner/model/module/Code.java
+++ b/src/main/java/pwe/planner/model/module/Code.java
@@ -30,7 +30,7 @@ public class Code implements Comparable<Code> {
         requireNonNull(code);
         checkArgument(isValidCode(code), MESSAGE_CONSTRAINTS);
 
-        value = code;
+        value = code.toUpperCase();
     }
 
     /**

--- a/src/test/java/pwe/planner/model/module/CodeTest.java
+++ b/src/test/java/pwe/planner/model/module/CodeTest.java
@@ -35,4 +35,15 @@ public class CodeTest {
         assertTrue(Code.isValidCode("IFS4231")); // starts with 3 alphabets
         assertTrue(Code.isValidCode("ABC1234D")); // starts with 3 alphabets and ends with optional alphabet
     }
+
+    @Test
+    public void equals() {
+        // case insensitive equals codes -> success
+        assertTrue(new Code("ABC1234D").equals(new Code("ABC1234D")));
+        assertTrue(new Code("ABC1234D").equals(new Code("abc1234d")));
+        assertTrue(new Code("ABC1234D").equals(new Code("aBc1234D")));
+
+        // case insensitive equals codes -> success
+        assertFalse(new Code("DEF5678").equals(new Code("DE5678F")));
+    }
 }


### PR DESCRIPTION
Code should be made case-insensitive, as `cs1010` and `CS1010`
essentially refers to the same module code. We should also disallow
storing module codes in lowercase to maintain consistency throughout our
application (as some module codes will be in uppercase, some will be in
lowercase).

Let's update `Code` to make it case-insensitive, but store them in
uppercase. Additionally, let's update the unit tests to ensure that
case-insensitive `Code` works as expected.