### PR TITLE
Ui: update `GuiSettings#DEFAULT_WIDTH` and `MainWindow.fxml`

### DIFF
--- a/src/main/java/pwe/planner/commons/core/GuiSettings.java
+++ b/src/main/java/pwe/planner/commons/core/GuiSettings.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_WIDTH = 960;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="PlanWithEase" minWidth="930" minHeight="600" onCloseRequest="#handleExit">
+         title="PlanWithEase" minWidth="960" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/plan_with_ease_32.png" />
   </icons>
@@ -47,7 +47,7 @@
         </StackPane>
 
         <SplitPane id="splitPane" fx:id="splitPane" dividerPositions="0.4, 0.5" VBox.vgrow="ALWAYS">
-          <VBox fx:id="moduleList" alignment="CENTER" minWidth="300" prefWidth="310">
+          <VBox fx:id="moduleList" alignment="CENTER" minWidth="290" prefWidth="310">
                 <Label alignment="CENTER" contentDisplay="CENTER" lineSpacing="9.0" text="Module List"
                        underline="true" styleClass="title_header">
                     <padding>
@@ -60,7 +60,7 @@
             </padding>
           </VBox>
 
-          <VBox fx:id="requirementCategories" alignment="CENTER" minWidth="300" prefWidth="310" VBox.vgrow="ALWAYS">
+          <VBox fx:id="requirementCategories" alignment="CENTER" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
               <Label alignment="CENTER" contentDisplay="CENTER" lineSpacing="9.0" text="Requirement Categories"
                      underline="true" styleClass="title_header">
                   <padding>


### PR DESCRIPTION
`GuiSettings#DEFAULT_WIDTH` does not match the minimum width of the root
element in `MainWindow.fxml`. Also, the `minWidth` of the Requirement
Categories panel needs to be increased, as the title of the panel can
become truncated if the width of the application window is minimum.

Let's update `GuiSettings#DEFAULT_WIDTH` to match `MainWindow.fxml`, and
let's also rescale the `minWidth` of all the main panels in
`MainWindow.fxml`.