### PR TITLE
Logic/requirement: enhance 'requirement_remove' logic

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
@@ -1,18 +1,18 @@
 package pwe.planner.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
-import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.logic.commands.exceptions.CommandException;
 import pwe.planner.model.Model;
 import pwe.planner.model.module.Code;
-import pwe.planner.model.module.Name;
 import pwe.planner.model.requirement.RequirementCategory;
 
 /**
@@ -22,32 +22,39 @@ public class RequirementRemoveCommand extends Command {
 
     public static final String COMMAND_WORD = "requirement_remove";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes a module from a requirement category.\n"
-            + "Parameters: "
-            + PREFIX_NAME + "NAME "
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD + ' '
             + PREFIX_CODE + "CODE "
             + "[" + PREFIX_CODE + "CODE]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "IT Professionalism "
             + PREFIX_CODE + "IS4231 ";
 
-    public static final String MESSAGE_SUCCESS = "Module removed from requirement category: %1$s";
-    public static final String MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY =
-            "The requirement category (%1$s) does not exist!";
-    public static final String MESSAGE_NONEXISTENT_CODE =
-            "The module to be removed from the requirement category does not exists in the module list!";
-    public static final String MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE =
-            "The module to be removed does not exists in %1$s";
+    // General command help details
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes module(s) from the requirement category.\n"
+            + FORMAT_AND_EXAMPLES;
 
-    private final Name toFind;
+    // Command success message
+    public static final String MESSAGE_SUCCESS = "Successfully removed module(s) (%1$s)";
+
+    //Command Failure messages
+    public static final String MESSAGE_NONEXISTENT_CODE = "You cannot specify module(s) (%1$s) that does not exist!\n"
+            + "Perhaps you misspelled a module code?\n"
+            + "[Tip] You are able to view all the modules in application using the \"list\" command.";
+
+    public static final String MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY =
+            "You cannot remove module(s) (%1$s) that does not exist in any requirement category!\n"
+            + "Perhaps you were trying to delete modules from the application?\n"
+            + "[Tip] You are able to delete a module from the application using the \"delete\" command.\n"
+            + "The module deleted will be automatically removed from the corresponding requirement category";
+
     private final Set<Code> toRemove = new HashSet<>();
 
     /**
-     * Creates an RequirementRemoveCommand to add the specified {@code Name, codeSet}
+     * Creates an RequirementRemoveCommand to remove the specified {@code codeSet}
      */
-    public RequirementRemoveCommand(Name name, Set<Code> codeSet) {
-        requireAllNonNull(name, codeSet);
-        this.toFind = name;
+    public RequirementRemoveCommand(Set<Code> codeSet) {
+        requireNonNull(codeSet);
+
         this.toRemove.addAll(codeSet);
     }
 
@@ -55,37 +62,69 @@ public class RequirementRemoveCommand extends Command {
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
 
-        RequirementCategory currentRequirementCategory = model.getRequirementCategory(toFind);
+        ObservableList<RequirementCategory> requirementCategories = model.getApplication().getRequirementCategoryList();
 
-        if (currentRequirementCategory == null) {
-            throw new CommandException(String.format(MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY, toFind));
+        List<Code> nonExistentCodes = toRemove.stream().filter(code -> !model.hasModuleCode(code))
+                .collect(Collectors.toList());
+
+        if (!nonExistentCodes.isEmpty()) {
+            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
         }
 
-        if (toRemove.stream().anyMatch(code -> !model.hasModuleCode(code))) {
-            throw new CommandException(MESSAGE_NONEXISTENT_CODE);
+        List<Code> codeNotInAnyRequirementCategory = toRemove.stream().filter(code -> requirementCategories.stream()
+                .noneMatch(requirementCategory -> requirementCategory.getCodeSet()
+                        .contains(code))).collect(Collectors.toList());
+
+        if (!codeNotInAnyRequirementCategory.isEmpty()) {
+            String codeNotInAnyRequirementCategoryErrorMessage = codeNotInAnyRequirementCategory.stream()
+                    .map(Code::toString).collect(Collectors.joining(", "));
+            throw new CommandException(String.format(MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
+                    codeNotInAnyRequirementCategoryErrorMessage));
         }
 
-        if (!currentRequirementCategory.getCodeSet().containsAll(toRemove)) {
-            throw new CommandException(String.format(MESSAGE_REQUIREMENT_CATEGORY_NONEXISTENT_CODE,
-                    currentRequirementCategory.getName()));
+        RequirementCategory singleSourceRequirementCategory = requirementCategories.stream()
+                .filter(requirementCategory -> requirementCategory.getCodeSet()
+                        .containsAll(toRemove)).findFirst().orElse(null);
+
+        //If all codes to be removed is from a requirement category only, all the codes can be removed together
+        if (singleSourceRequirementCategory != null) {
+            Set<Code> newCodeSet = new HashSet<>(singleSourceRequirementCategory.getCodeSet());
+            newCodeSet.removeAll(toRemove);
+
+            RequirementCategory editedRequirementCategory = new RequirementCategory(
+                    singleSourceRequirementCategory.getName(), singleSourceRequirementCategory.getCredits(),
+                    newCodeSet);
+
+            model.setRequirementCategory(singleSourceRequirementCategory, editedRequirementCategory);
+        } else {
+            //If all codes to be removed are from multiple requirement category, have to remove the codes individually
+            for (Code code : toRemove) {
+                RequirementCategory sourceRequirementCategory = requirementCategories.stream()
+                        .filter(reqCat -> reqCat.getCodeSet().contains(code)).findFirst().orElse(null);
+
+                Set<Code> newCodeSet = new HashSet<>(sourceRequirementCategory.getCodeSet());
+                newCodeSet.remove(code);
+
+                RequirementCategory editedRequirementCategory = new RequirementCategory(
+                        sourceRequirementCategory.getName(), sourceRequirementCategory.getCredits(), newCodeSet);
+
+                model.setRequirementCategory(sourceRequirementCategory, editedRequirementCategory);
+
+            }
         }
 
-        Set<Code> newCodeSet = new HashSet<>(currentRequirementCategory.getCodeSet());
-        newCodeSet.removeAll(toRemove);
+        String codesMoved = toRemove.stream().map(Code::toString).collect(Collectors.joining(", "));
 
-        RequirementCategory editedRequirementCategory = new RequirementCategory(
-                currentRequirementCategory.getName(), currentRequirementCategory.getCredits(), newCodeSet
-        );
-        model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         model.commitApplication();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, currentRequirementCategory.getName()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, codesMoved));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof RequirementRemoveCommand // instanceof handles nulls
-                && toFind.equals(((RequirementRemoveCommand) other).toFind)
                 && toRemove.equals(((RequirementRemoveCommand) other).toRemove));
     }
 }

--- a/src/main/java/pwe/planner/logic/parser/RequirementRemoveCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/RequirementRemoveCommandParser.java
@@ -3,17 +3,14 @@ package pwe.planner.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
-import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static pwe.planner.logic.parser.ParserUtil.arePrefixesPresent;
 import static pwe.planner.logic.parser.ParserUtil.parseCodes;
-import static pwe.planner.logic.parser.ParserUtil.parseName;
 
 import java.util.Set;
 
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.logic.parser.exceptions.ParseException;
 import pwe.planner.model.module.Code;
-import pwe.planner.model.module.Name;
 
 /**
  * Parses input arguments and creates a new RequirementRemoveCommand object
@@ -28,16 +25,19 @@ public class RequirementRemoveCommandParser implements Parser<RequirementRemoveC
     public RequirementRemoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE);
+        if (args.isEmpty()) {
+            throw new ParseException(RequirementRemoveCommand.MESSAGE_USAGE);
+        }
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE) || !argMultimap.getPreamble().isEmpty()) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_CODE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_CODE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, RequirementRemoveCommand.MESSAGE_USAGE));
         }
 
-        Name name = parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Set<Code> codeList = parseCodes(argMultimap.getAllValues(PREFIX_CODE));
+        Set<Code> codeSet = parseCodes(argMultimap.getAllValues(PREFIX_CODE));
 
-        return new RequirementRemoveCommand(name, codeList);
+        return new RequirementRemoveCommand(codeSet);
     }
 }

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -195,10 +195,9 @@ public class CommandParserTest {
     @Test
     public void parseCommand_requirementRemove() throws Exception {
         Set<Code> codeSet = Set.of(new Code("CS1010"));
-        RequirementRemoveCommand command = (RequirementRemoveCommand)
-                parser.parseCommand(RequirementUtil.getRequirementRemoveCommand(
-                        new Name("Computing Foundation"), codeSet));
-        assertEquals(new RequirementRemoveCommand(new Name("Computing Foundation"), codeSet), command);
+        RequirementRemoveCommand command = (RequirementRemoveCommand) parser.parseCommand(
+                RequirementUtil.getRequirementRemoveCommand(codeSet));
+        assertEquals(new RequirementRemoveCommand(codeSet), command);
     }
 
     @Test

--- a/src/test/java/pwe/planner/logic/parser/RequirementRemoveCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/RequirementRemoveCommandParserTest.java
@@ -4,68 +4,81 @@ import static pwe.planner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static pwe.planner.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
-import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
 
 import pwe.planner.logic.commands.RequirementRemoveCommand;
 import pwe.planner.model.module.Code;
-import pwe.planner.model.module.Name;
 
 public class RequirementRemoveCommandParserTest {
 
     private RequirementRemoveCommandParser parser = new RequirementRemoveCommandParser();
 
     @Test
+    public void parse_nullValue_failure() {
+        //empty input
+        assertParseFailure(parser, "", RequirementRemoveCommand.MESSAGE_USAGE);
+
+    }
+
+    @Test
     public void parse_invalidValue_failure() {
-        // invalid format
+        // invalid format -> false
         assertParseFailure(parser, " INVALID INPUT", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 RequirementRemoveCommand.MESSAGE_USAGE));
 
-        // invalid name format
-        assertParseFailure(parser, " " + PREFIX_NAME + "  " + PREFIX_CODE + "CS1010 ",
-                Name.MESSAGE_CONSTRAINTS);
+        // invalid code format -> false
+        assertParseFailure(parser, " " + PREFIX_CODE + "1231", Code.MESSAGE_CONSTRAINTS);
 
-        // invalid code format
-        assertParseFailure(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "1231",
+        // invalid code format -> false
+        assertParseFailure(parser, " " + PREFIX_CODE + "CS1010 " + PREFIX_CODE + "1231",
                 Code.MESSAGE_CONSTRAINTS);
 
-        // invalid name and code format
-        assertParseFailure(parser, " " + PREFIX_NAME + "   " + PREFIX_CODE + "1231",
-                Name.MESSAGE_CONSTRAINTS);
+        // invalid code format -> false
+        assertParseFailure(parser, " " + PREFIX_CODE + "1010 " + PREFIX_CODE + "CS1231",
+                Code.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
+        // non-empty preamble -> false
         assertParseFailure(parser,
-                PREAMBLE_NON_EMPTY + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1231",
+                PREAMBLE_NON_EMPTY + " " + PREFIX_CODE + "CS1231",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, RequirementRemoveCommand.MESSAGE_USAGE));
 
     }
 
     @Test
-    public void parse_validArgs_returnsRequirementDeleteCommand() {
-        Name validName = new Name("Computing Foundation");
-        Set<Code> validCodeSet = new HashSet<>();
-        validCodeSet.add(new Code("CS1010"));
+    public void parse_validArgs_returnsRequirementRemoveCommand() {
+        Set<Code> validCodeSet = Set.of(new Code("CS1010"));
+        Set<Code> validMultiCodeSet = Set.of(new Code("CS1010"), new Code("CS1231"));
 
-        RequirementRemoveCommand expectedRequirementRemoveCommand =
-                new RequirementRemoveCommand(validName, validCodeSet);
+        RequirementRemoveCommand expectedRequirementRemoveCommand = new RequirementRemoveCommand(validCodeSet);
 
-        assertParseSuccess(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+        //normal command -> true
+        assertParseSuccess(parser, " " + PREFIX_CODE + "CS1010", expectedRequirementRemoveCommand);
+
+        // whitespace only preamble -> true
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_CODE + "CS1010",
                 expectedRequirementRemoveCommand);
 
-        // whitespace only preamble
-        assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+        // same command -> true
+        assertParseSuccess(parser, " " + PREFIX_CODE + "CS1010 ", expectedRequirementRemoveCommand);
+
+        expectedRequirementRemoveCommand = new RequirementRemoveCommand(validMultiCodeSet);
+
+        //normal command with multi codes -> true
+        assertParseSuccess(parser, " " + PREFIX_CODE + "CS1010 " + PREFIX_CODE + "CS1231",
                 expectedRequirementRemoveCommand);
 
-        // multiple requirement categories specified - last requirement category accepted
-        assertParseSuccess(parser, " " + PREFIX_NAME + "Mathematics " + PREFIX_NAME
-                + "Computing Foundation " + PREFIX_CODE + "CS1010", expectedRequirementRemoveCommand);
+        //whitespace only preamble -> true
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + " " + PREFIX_CODE + "CS1010 " + PREFIX_CODE + "CS1231",
+                expectedRequirementRemoveCommand);
+
+        // same command -> true
+        assertParseSuccess(parser, " " + PREFIX_CODE + "CS1010 " + PREFIX_CODE + "CS1231",
+                expectedRequirementRemoveCommand);
 
     }
 }

--- a/src/test/java/pwe/planner/testutil/RequirementUtil.java
+++ b/src/test/java/pwe/planner/testutil/RequirementUtil.java
@@ -18,10 +18,9 @@ public class RequirementUtil {
     /**
      * Returns an remove command string for removing the {@code code}.
      */
-    public static String getRequirementRemoveCommand(Name requirementCategoryName, Set<Code> codeSet) {
+    public static String getRequirementRemoveCommand(Set<Code> codeSet) {
         StringBuilder sb = new StringBuilder();
         sb.append(RequirementRemoveCommand.COMMAND_WORD).append(" ");
-        sb.append(PREFIX_NAME).append(requirementCategoryName.toString()).append(" ");
         codeSet.stream().forEach(s -> sb.append(PREFIX_CODE).append(s.value).append(" "));
         return sb.toString();
     }


### PR DESCRIPTION
Our application allows users to remove modules from the specified 
requirement category. However, when entering the `requirement_remove`
command the `name` of the requirement category and the `code` to be 
removed has to be specified by the user.

This is inefficient as the users should be able to remove the modules codes
 from the requirement categories by specifying the `code` 

To address these issues, let's enhance the `requirement_remove` command 
to allow users to able to remove the codes without specifying the `name` of the 
requirement category.

* [1/3] [Logic: update 'requirement_remove' command logic](https://github.com/CS2113-AY1819S2-T09-1/main/pull/213/commits/93fbb76ce3ad082ab1545fd0e9372fdc8987b858)
* [2/3] [test/parser: update test case for updated command logic](https://github.com/CS2113-AY1819S2-T09-1/main/pull/213/commits/398096eb3346970d679fa863499a8dc66b7377d9)
* [3/3] [test/logic: update test cases to reflect new command logic](https://github.com/CS2113-AY1819S2-T09-1/main/pull/213/commits/2be3da0e8b3bf08440f56118157424bbca5948a9)
