### PR TITLE
Logic: add new `reset` command

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/ResetCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/ResetCommand.java
@@ -1,0 +1,26 @@
+package pwe.planner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.model.Model;
+import pwe.planner.model.util.SampleDataUtil;
+
+/**
+ * Populate the application with sample data.
+ */
+public class ResetCommand extends Command {
+    public static final String COMMAND_WORD = "reset";
+    public static final String MESSAGE_SUCCESS = "Application has been populated with the sample data!\n"
+            + "[Tip] If you unintentionally used this command, do use the undo command to revert back the changes!";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+
+        model.setApplication(SampleDataUtil.getSampleApplication());
+        model.commitApplication();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}
+

--- a/src/main/java/pwe/planner/logic/parser/CommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/CommandParser.java
@@ -24,6 +24,7 @@ import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
+import pwe.planner.logic.commands.ResetCommand;
 import pwe.planner.logic.commands.SelectCommand;
 import pwe.planner.logic.commands.UndoCommand;
 import pwe.planner.logic.parser.exceptions.ParseException;
@@ -71,6 +72,9 @@ public class CommandParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommandParser().parse(arguments);
+
+        case ResetCommand.COMMAND_WORD:
+            return new ResetCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/test/java/pwe/planner/logic/commands/ResetCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/ResetCommandTest.java
@@ -1,0 +1,25 @@
+package pwe.planner.logic.commands;
+
+import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.Test;
+
+import pwe.planner.logic.CommandHistory;
+import pwe.planner.model.Model;
+import pwe.planner.model.ModelManager;
+import pwe.planner.model.util.SampleDataUtil;
+
+public class ResetCommandTest {
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_reset_command() {
+        Model model = new ModelManager();
+        Model expectedModel = new ModelManager();
+        expectedModel.setApplication(SampleDataUtil.getSampleApplication());
+        expectedModel.commitApplication();
+
+        assertCommandSuccess(new ResetCommand(), model, commandHistory, ResetCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+}

--- a/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/CommandParserTest.java
@@ -35,6 +35,7 @@ import pwe.planner.logic.commands.RedoCommand;
 import pwe.planner.logic.commands.RequirementAddCommand;
 import pwe.planner.logic.commands.RequirementListCommand;
 import pwe.planner.logic.commands.RequirementRemoveCommand;
+import pwe.planner.logic.commands.ResetCommand;
 import pwe.planner.logic.commands.SelectCommand;
 import pwe.planner.logic.commands.UndoCommand;
 import pwe.planner.logic.parser.exceptions.ParseException;
@@ -66,6 +67,12 @@ public class CommandParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " planner") instanceof ClearCommand);
+    }
+
+    @Test
+    public void parseCommand_reset() throws Exception {
+        assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD) instanceof ResetCommand);
+        assertTrue(parser.parseCommand(ResetCommand.COMMAND_WORD + " abc") instanceof ResetCommand);
     }
 
     @Test


### PR DESCRIPTION
We could reset the sample data we have by simply delete the `.json`
file, however, the user have no easy way to do so.

Let's create a new command `reset` to reset all data to sample data.