### PR TITLE
MainApp: bump `MainApp#VERSION` to v1.4 for release

### DIFF
--- a/src/main/java/pwe/planner/MainApp.java
+++ b/src/main/java/pwe/planner/MainApp.java
@@ -38,7 +38,7 @@ import pwe.planner.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 0, false);
+    public static final Version VERSION = new Version(1, 4, 0, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 


### PR DESCRIPTION
To prepare for v1.4 release, let's bump `MainApp#VERSION` to v1.4.