### PR TITLE
Logic/commands: enhance logic checks for module management commands

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -983,11 +983,25 @@ _{More to be added}_
 specified otherwise)
 
 [discrete]
-=== Use case: Add a module to Application
+=== Use Case: Clear All Modules in Application
 
 *MSS*
 
-1. User requests to add a module
+1.  User requests to clear all modules in the module list
+2.  Application clear all modules in the module list
++
+Use case ends.
+
+*Extensions*
+[none]
+* None
+
+[discrete]
+=== Use case: Add a Module to Module List
+
+*MSS*
+
+1. User requests to add a module to the module list
 2. Application adds the module into the module list
 +
 Use case ends.
@@ -996,45 +1010,25 @@ Use case ends.
 
 [none]
 * 1a. The given input is invalid.
-[none]
 ** 1a1. Application shows an error message that given input is invalid.
 +
 Use case ends.
 * 1b. The module already exists in the module list.
-[none]
 ** 1b1. Application shows an error message that module specified by user already exists in module list.
 +
 Use case ends.
-
-[discrete]
-=== Use case: Delete module from Application
-
-*MSS*
-
-1.  User requests to list modules
-2.  Application shows a list of modules
-3.  User requests to delete a specific module in the module list
-4.  Application deletes the module in the module list
+* 1c. The module to be added has a corequisite that does not exists in the module list.
+** 1c1. Application shows an error message that module specified by user has a non-existent corequisite.
++
+Use case ends.
+* 1d. The module to be added has a corequisite that exists in the degree plan.
+** 1d1. Application shows an error message that module specified by user has a corequisite that exists in the degree
+plan.
 +
 Use case ends.
 
-*Extensions*
-
-[none]
-* 2a. The list is empty.
-+
-Use case ends.
-
-[none]
-* 3a. The given index is invalid.
-+
-[none]
-** 3a1. Application shows an error message.
-+
-Use case resumes at step 2.
-
 [discrete]
-=== Use case: Edit module from Application
+=== Use Case: Edit a Module in Application
 
 *MSS*
 
@@ -1069,6 +1063,47 @@ Use case resumes at step 2.
 Use case ends.
 
 [discrete]
+=== Use Case: Delete a Module in Application
+
+*MSS*
+
+1.  User requests to list modules
+2.  Application shows a list of modules
+3.  User requests to delete a specific module in the module list
+4.  Application deletes the module in the module list
++
+Use case ends.
+
+*Extensions*
+
+[none]
+* 2a. The list is empty.
++
+Use case ends.
+
+[none]
+* 3a. The given index is invalid.
++
+[none]
+** 3a1. Application shows an error message.
++
+Use case resumes at step 2.
+
+[discrete]
+=== Use Case: List All Modules in Application
+
+*MSS*
+
+1.  User requests to list all modules in the module list
+2.  Application shows a list of all modules in the module list
++
+Use case ends.
+
+*Extensions*
+[none]
+* None
+
+[discrete]
 === Use case: Find a module in Application
 *Guarantee(s):*
 [none]
@@ -1089,34 +1124,6 @@ Use case ends.
 ** 1a1. Application shows an error message that given input is invalid.
 +
 Use case ends.
-
-[discrete]
-=== Use case: List all modules in Application
-
-*MSS*
-
-1.  Student requests to list all modules in the module list
-2.  Application shows a list of all modules in the module list
-+
-Use case ends.
-
-*Extensions*
-[none]
-* None
-
-[discrete]
-=== Use case: Clear all modules in Application
-
-*MSS*
-
-1.  Student requests to clear all modules in the module list
-2.  Application clear all modules in the module list
-+
-Use case ends.
-
-*Extensions*
-[none]
-* None
 
 [discrete]
 === Use case: Add module(s) to degree plan

--- a/src/main/java/pwe/planner/commons/util/StringUtil.java
+++ b/src/main/java/pwe/planner/commons/util/StringUtil.java
@@ -7,11 +7,36 @@ import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Helper functions for handling strings.
  */
 public class StringUtil {
+
+    /**
+     * Returns a string of all elements of the stream separated by commas.
+     * If there are no elements in the stream, returns "None".
+     * Syntactic sugar for {@code joinStreamAsString(stream, ", ")}
+     * @param stream stream of elements to join
+     */
+    public static String joinStreamAsString(Stream<?> stream) {
+        return joinStreamAsString(stream, ", ");
+    }
+
+    /**
+     * Returns a string of all elements of the stream separated by delimiter.
+     * If there are no elements in the stream, returns "None".
+     * @param stream stream of elements to join
+     * @param delimiter string used to separate the elements when joining them together as a string
+     */
+    public static String joinStreamAsString(Stream<?> stream, String delimiter) {
+        requireAllNonNull(stream, delimiter);
+
+        String joinnedString = stream.map(Object::toString).collect(Collectors.joining(delimiter));
+        return (joinnedString.isEmpty()) ? "None" : joinnedString;
+    }
 
     /**
      * Returns true if the {@code sentence} contains the {@code word}.

--- a/src/main/java/pwe/planner/logic/commands/AddCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/AddCommand.java
@@ -19,7 +19,6 @@ import pwe.planner.model.module.Module;
  * Adds a {@link Module} to the {@link Application#modules module list}.
  */
 public class AddCommand extends Command {
-
     public static final String COMMAND_WORD = "add";
 
     // This is declared before MESSAGE_USAGE to prevent illegal forward reference
@@ -59,6 +58,12 @@ public class AddCommand extends Command {
             + "Afterwards, add the module (%2$s) and specify the module (%1$s) as a co-requisite.\n"
             + "This will make both modules (%1$s & %2$s) co-requisites!";
 
+    public static final String MESSAGE_EXISTING_COREQUISITES_IN_DEGREE_PLAN =
+            "You cannot add a new module (%1$s) that has a co-requisite module (%2$s) that exists in the degree plan!\n"
+            + "[Tip] You can remove the module (%2$s) from the degree plan first, add the module (%1$s) and specify "
+            + "(%2$s) as a co-requisite, then add back the module (%2$s) to the degree plan.\n"
+            + "This will make both modules (%1$s & %2$s) co-requisites!";
+
     private final Module toAdd;
 
     /**
@@ -82,6 +87,11 @@ public class AddCommand extends Command {
             if (!model.hasModuleCode(corequisite)) {
                 throw new CommandException(String.format(
                         MESSAGE_NON_EXISTENT_COREQUISITE, toAdd.getCode(), corequisite)
+                );
+            }
+            if (model.getDegreePlannerByCode(corequisite) != null) {
+                throw new CommandException(String.format(
+                        MESSAGE_EXISTING_COREQUISITES_IN_DEGREE_PLAN, toAdd.getCode(), corequisite)
                 );
             }
         }

--- a/src/main/java/pwe/planner/logic/commands/DeleteCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/DeleteCommand.java
@@ -30,6 +30,8 @@ public class DeleteCommand extends Command {
             + ": Deletes a module in the displayed module list.\n"
             + "To choose which module you want to delete, please include the index number "
             + "(beside the module code) in the displayed module list.\n"
+            + "Note: This will also remove the module from the degree plan, the requirement categories and other "
+            + "modules' corequisites (where applicable)."
             + FORMAT_AND_EXAMPLES;
 
     public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Successfully deleted the module:\n%1$s";

--- a/src/main/java/pwe/planner/logic/commands/PlannerListCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/PlannerListCommand.java
@@ -3,8 +3,9 @@ package pwe.planner.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.model.Model.PREDICATE_SHOW_ALL_DEGREE_PLANNERS;
 
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.planner.DegreePlanner;
@@ -23,9 +24,8 @@ public class PlannerListCommand extends Command {
         requireNonNull(model);
 
         model.updateFilteredDegreePlannerList(PREDICATE_SHOW_ALL_DEGREE_PLANNERS);
-        String degreePlannerListContent = model.getApplication().getDegreePlannerList().stream()
-                .map(DegreePlanner::toString)
-                .collect(Collectors.joining("\n"));
+        Stream<DegreePlanner> degreePlannersStream = model.getApplication().getDegreePlannerList().stream().sorted();
+        String degreePlannerListContent = StringUtil.joinStreamAsString(degreePlannersStream, "\n");
         return new CommandResult(String.format(MESSAGE_SUCCESS, degreePlannerListContent));
     }
 }

--- a/src/main/java/pwe/planner/logic/commands/RequirementListCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementListCommand.java
@@ -3,12 +3,10 @@ package pwe.planner.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.model.Model.PREDICATE_SHOW_ALL_REQUIREMENT_CATEGORIES;
 
-import java.util.stream.Collectors;
-
 import javafx.collections.ObservableList;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
-import pwe.planner.model.module.Code;
 import pwe.planner.model.requirement.RequirementCategory;
 
 /**
@@ -41,8 +39,8 @@ public class RequirementListCommand extends Command {
             if (requirementCategory.getCodeSet().isEmpty()) {
                 requirementListContent.append("No modules added!");
             } else {
-                requirementListContent.append("Modules: ").append(requirementCategory.getCodeSet().stream()
-                        .map(Code::toString).sorted().collect(Collectors.joining(", ")));
+                requirementListContent.append("Modules: ")
+                        .append(StringUtil.joinStreamAsString(requirementCategory.getCodeSet().stream().sorted()));
             }
 
             requirementListContent.append("\n\n");

--- a/src/main/java/pwe/planner/model/Application.java
+++ b/src/main/java/pwe/planner/model/Application.java
@@ -249,15 +249,15 @@ public class Application implements ReadOnlyApplication {
     }
 
     /**
-     * Removes {@code key} from this {@code Application}.
-     * {@code key} must exist in the application.
+     * Deletes {@code module} from this {@code Application}.
+     * {@code moduleToDelete} must exist in the application.
      */
-    public void removeModule(Module key) {
-        requireNonNull(key);
+    public void removeModule(Module moduleToDelete) {
+        requireNonNull(moduleToDelete);
 
-        modules.remove(key);
-        cascadeDeletedCodeInDegreePlanners(key.getCode());
-        cascadeDeletedCodeInRequirementCategories(key.getCode());
+        modules.remove(moduleToDelete);
+        cascadeDeleteCodeToDegreePlanners(moduleToDelete.getCode());
+        cascadeDeleteCodeToRequirementCategories(moduleToDelete.getCode());
         indicateModified();
     }
 
@@ -265,8 +265,8 @@ public class Application implements ReadOnlyApplication {
      * Cascades the deleted module code by removing it from {@code UniqueDegreePlannerList} accordingly
      * @param codeToDelete module code to delete
      */
-    private void cascadeDeletedCodeInDegreePlanners(Code codeToDelete) {
-        requireNonNull(codeToDelete);
+    private void cascadeDeleteCodeToDegreePlanners(Code codeToDelete) {
+        assert codeToDelete != null;
 
         ObservableList<DegreePlanner> degreePlanners = getDegreePlannerList();
         for (DegreePlanner degreePlanner : degreePlanners) {
@@ -289,8 +289,8 @@ public class Application implements ReadOnlyApplication {
      * Cascades the deleted module code by removing it from {@code UniqueRequirementCategoryList} accordingly
      * @param codeToDelete module code to delete
      */
-    private void cascadeDeletedCodeInRequirementCategories(Code codeToDelete) {
-        requireNonNull(codeToDelete);
+    private void cascadeDeleteCodeToRequirementCategories(Code codeToDelete) {
+        assert codeToDelete != null;
 
         ObservableList<RequirementCategory> requirementCategories = getRequirementCategoryList();
         for (RequirementCategory requirementCategory : requirementCategories) {

--- a/src/main/java/pwe/planner/model/module/Module.java
+++ b/src/main/java/pwe/planner/model/module/Module.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.model.planner.Semester;
 import pwe.planner.model.tag.Tag;
 
@@ -128,17 +128,11 @@ public class Module {
     @Override
     public String toString() {
 
-        final String allSemesters = semesters.isEmpty()
-                ? "None"
-                : semesters.stream().sorted().map(Semester::toString).collect(Collectors.joining(", "));
+        final String allSemesters = StringUtil.joinStreamAsString(semesters.stream().sorted());
 
-        final String allCorequisites = corequisites.isEmpty()
-                ? "None"
-                : corequisites.stream().sorted().map(Code::toString).collect(Collectors.joining(", "));
+        final String allCorequisites = StringUtil.joinStreamAsString(corequisites.stream().sorted());
 
-        final String allTags = tags.isEmpty()
-                ? "None"
-                : tags.stream().sorted().map(Tag::toString).collect(Collectors.joining(", "));
+        final String allTags = StringUtil.joinStreamAsString(tags.stream().sorted());
 
         return String.format(STRING_REPRESENTATION, code, name, credits, allSemesters, allCorequisites, allTags);
     }

--- a/src/main/java/pwe/planner/model/module/UniqueModuleList.java
+++ b/src/main/java/pwe/planner/model/module/UniqueModuleList.java
@@ -64,7 +64,7 @@ public class UniqueModuleList implements Iterable<Module> {
         }
         internalList.add(toAdd);
 
-        cascadeAddModuleCorequisites(toAdd);
+        cascadeAddToModuleCorequisites(toAdd);
     }
 
     /**
@@ -73,7 +73,7 @@ public class UniqueModuleList implements Iterable<Module> {
      *
      * @param moduleToAdd
      */
-    private void cascadeAddModuleCorequisites(Module moduleToAdd) {
+    private void cascadeAddToModuleCorequisites(Module moduleToAdd) {
         assert moduleToAdd != null;
 
         // create a union Set<Code> of co-requisites
@@ -151,10 +151,10 @@ public class UniqueModuleList implements Iterable<Module> {
 
         if (cascade) {
             if (!target.getCode().equals(editedModule.getCode())) {
-                cascadeEditModuleCorequisites(target, editedModule);
+                cascadeEditToModuleCorequisites(target, editedModule);
             }
-            cascadeDeleteModuleCorequisites(target);
-            cascadeAddModuleCorequisites(editedModule);
+            cascadeDeleteToModuleCorequisites(target);
+            cascadeAddToModuleCorequisites(editedModule);
         }
     }
 
@@ -163,7 +163,7 @@ public class UniqueModuleList implements Iterable<Module> {
      * @param target module code to edit/find
      * @param editedModule module code to replace with
      */
-    private void cascadeEditModuleCorequisites(Module target, Module editedModule) {
+    private void cascadeEditToModuleCorequisites(Module target, Module editedModule) {
         assert target != null;
         assert editedModule != null;
 
@@ -202,14 +202,14 @@ public class UniqueModuleList implements Iterable<Module> {
             throw new ModuleNotFoundException();
         }
 
-        cascadeDeleteModuleCorequisites(toRemove);
+        cascadeDeleteToModuleCorequisites(toRemove);
     }
 
     /**
      * Cascades the deleted module code by removing it from {@code UniqueModuleList} accordingly
      * @param moduleToDelete module code to delete
      */
-    private void cascadeDeleteModuleCorequisites(Module moduleToDelete) {
+    private void cascadeDeleteToModuleCorequisites(Module moduleToDelete) {
         assert moduleToDelete != null;
 
         ObservableList<Module> modules = internalUnmodifiableList;

--- a/src/main/java/pwe/planner/model/planner/DegreePlanner.java
+++ b/src/main/java/pwe/planner/model/planner/DegreePlanner.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.model.module.Code;
 
 /**
@@ -93,7 +93,7 @@ public class DegreePlanner implements Comparable<DegreePlanner> {
     public String toString() {
         final String allCodes = codes.isEmpty()
                 ? "No modules"
-                : codes.stream().sorted().map(Code::toString).collect(Collectors.joining(", "));
+                : StringUtil.joinStreamAsString(codes.stream().sorted());
 
         return String.format(STRING_REPRESENTATION, year, semester, allCodes);
     }

--- a/src/main/java/pwe/planner/storage/JsonSerializableApplication.java
+++ b/src/main/java/pwe/planner/storage/JsonSerializableApplication.java
@@ -3,10 +3,10 @@ package pwe.planner.storage;
 import static pwe.planner.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.model.Application;
 import pwe.planner.model.module.Code;
 import pwe.planner.model.module.Module;
@@ -126,8 +126,7 @@ public class JsonSerializableApplication {
                                 MESSAGE_INVALID_DEGREE_PLANNER_EMPTY_MODULE_SEMESTERS, code, degreePlanner.getYear(),
                                 degreePlanner.getSemester()));
                     } else {
-                        String semestersOfferingModule = semesters.stream().sorted().map(Semester::toString)
-                                .collect(Collectors.joining(", "));
+                        String semestersOfferingModule = StringUtil.joinStreamAsString(semesters.stream().sorted());
                         throw new IllegalValueException(String.format(MESSAGE_INVALID_DEGREE_PLANNER_MODULE_SEMESTER,
                                 code, degreePlanner.getYear(), degreePlanner.getSemester(), semestersOfferingModule));
                     }

--- a/src/main/java/pwe/planner/ui/ModuleCard.java
+++ b/src/main/java/pwe/planner/ui/ModuleCard.java
@@ -2,16 +2,13 @@ package pwe.planner.ui;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.stream.Collectors;
-
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
-import pwe.planner.model.module.Code;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.model.module.Module;
-import pwe.planner.model.planner.Semester;
 
 /**
  * An UI component that displays information of a {@code Module}.
@@ -56,18 +53,10 @@ public class ModuleCard extends UiPart<Region> {
         credits.setText("Modular Credits: " + module.getCredits().value);
         code.setText(module.getCode().value);
 
-        String semestersText = module.getSemesters().stream().map(Semester::toString)
-                .collect(Collectors.joining(", "));
-        if (semestersText.length() == 0) {
-            semestersText = "None";
-        }
+        String semestersText = StringUtil.joinStreamAsString(module.getSemesters().stream().sorted());
         semesters.setText("Offered in Semesters: " + semestersText);
 
-        String corequisitesText = module.getCorequisites().stream().map(Code::toString)
-                .collect(Collectors.joining(", "));
-        if (corequisitesText.length() == 0) {
-            corequisitesText = "None";
-        }
+        String corequisitesText = StringUtil.joinStreamAsString(module.getCorequisites().stream().sorted());
         corequisites.setText("Co-requisites: " + corequisitesText);
         module.getTags().stream().sorted().forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }

--- a/src/test/java/pwe/planner/commons/util/StringUtilTest.java
+++ b/src/test/java/pwe/planner/commons/util/StringUtilTest.java
@@ -2,11 +2,13 @@ package pwe.planner.commons.util;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,6 +18,46 @@ public class StringUtilTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    //---------------- Tests for joinStreamAsString --------------------------------------------
+
+    @Test
+    public void joinStreamAsString_nullStream_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        StringUtil.joinStreamAsString(null);
+    }
+
+    @Test
+    public void joinStreamAsString_nullStreamNonNullDelimiter_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        StringUtil.joinStreamAsString(null, "delimiter");
+    }
+
+    @Test
+    public void joinStreamAsString_nonNullStreamNullDelimiter_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        StringUtil.joinStreamAsString(Stream.of(), null);
+    }
+
+    @Test
+    public void joinStreamAsString_emptyStreamNonEmptyDelimiter_success() {
+        // use default delimiter on empty string -> success
+        assertEquals(StringUtil.joinStreamAsString(Stream.of()), "None");
+        // use custom delimiter on empty string -> success
+        assertEquals(StringUtil.joinStreamAsString(Stream.of(), "delimiter"), "None");
+    }
+
+    @Test
+    public void joinStreamAsString_nonEmptyStreamEmptyDelimiter_success() {
+        assertEquals(StringUtil.joinStreamAsString(Stream.of(), ""), "None");
+        assertEquals(StringUtil.joinStreamAsString(Stream.of("A", "B", "C"), "   "), "A   B   C");
+    }
+
+    @Test
+    public void joinStreamAsString_mixedElementsInStream_success() {
+        assertEquals(StringUtil.joinStreamAsString(Stream.of("A", 'b', 3)), "A, b, 3");
+        assertEquals(StringUtil.joinStreamAsString(Stream.of("A", 'b', 3), "\n"), "A\nb\n3");
+    }
 
     //---------------- Tests for isNonZeroUnsignedInteger --------------------------------------
 

--- a/src/test/java/pwe/planner/logic/LogicManagerTest.java
+++ b/src/test/java/pwe/planner/logic/LogicManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.commands.AddCommand;
 import pwe.planner.logic.commands.CommandResult;
 import pwe.planner.logic.commands.HistoryCommand;
@@ -33,7 +34,6 @@ import pwe.planner.model.ModelManager;
 import pwe.planner.model.ReadOnlyApplication;
 import pwe.planner.model.UserPrefs;
 import pwe.planner.model.module.Module;
-import pwe.planner.model.planner.DegreePlanner;
 import pwe.planner.storage.JsonApplicationStorage;
 import pwe.planner.storage.JsonUserPrefsStorage;
 import pwe.planner.storage.StorageManager;
@@ -85,9 +85,8 @@ public class LogicManagerTest {
     @Test
     public void execute_validPlannerListCommand_success() {
         String plannerListCommand = PlannerListCommand.COMMAND_WORD;
-        String degreePlannerListContent = model.getApplication().getDegreePlannerList().stream()
-                .map(DegreePlanner::toString)
-                .collect(Collectors.joining("\n"));
+        String degreePlannerListContent = StringUtil.joinStreamAsString(
+                model.getApplication().getDegreePlannerList().stream().sorted());
         String expectedMessage = String.format(PlannerListCommand.MESSAGE_SUCCESS, degreePlannerListContent);
         assertCommandSuccess(plannerListCommand, expectedMessage, model);
         assertHistoryCorrect(plannerListCommand);

--- a/src/test/java/pwe/planner/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/pwe/planner/logic/commands/AddCommandIntegrationTest.java
@@ -2,20 +2,17 @@ package pwe.planner.logic.commands;
 
 import static pwe.planner.logic.commands.CommandTestUtil.assertCommandFailure;
 import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
-import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
-import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
+import static pwe.planner.testutil.TypicalIndexes.INDEX_FIRST_MODULE;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import pwe.planner.commons.exceptions.IllegalValueException;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
 import pwe.planner.model.UserPrefs;
 import pwe.planner.model.module.Module;
-import pwe.planner.storage.JsonSerializableApplication;
+import pwe.planner.model.util.SampleDataUtil;
 import pwe.planner.testutil.ModuleBuilder;
 
 /**
@@ -27,10 +24,8 @@ public class AddCommandIntegrationTest {
     private CommandHistory commandHistory = new CommandHistory();
 
     @Before
-    public void setUp() throws IllegalValueException {
-        //ToDo: Implement getTypicalDegreePlannerList for DegreePlannerList and update the codes below
-        model = new ModelManager(new JsonSerializableApplication(getTypicalModuleList(), getTypicalDegreePlannerList(),
-                getTypicalRequirementCategoriesList()).toModelType(), new UserPrefs());
+    public void setUp() {
+        model = new ModelManager(SampleDataUtil.getSampleApplication(), new UserPrefs());
     }
 
     @Test
@@ -46,10 +41,28 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_duplicateModule_throwsCommandException() {
-        Module moduleInList = model.getApplication().getModuleList().get(0);
+        Module moduleInList = model.getApplication().getModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
         assertCommandFailure(new AddCommand(moduleInList), model, commandHistory,
                 String.format(AddCommand.MESSAGE_DUPLICATE_MODULE, moduleInList.getCode())
         );
     }
 
+    @Test
+    public void execute_nonExistentCorequisites_throwsCommandException() {
+        String nonExistentCorequisite = "ZYX9876W";
+        Module moduleWithOnlyInvalidCorequisites = new ModuleBuilder().withCorequisites(nonExistentCorequisite).build();
+        String expectedMessage = String.format(AddCommand.MESSAGE_NON_EXISTENT_COREQUISITE,
+                moduleWithOnlyInvalidCorequisites.getCode(), nonExistentCorequisite);
+        assertCommandFailure(new AddCommand(moduleWithOnlyInvalidCorequisites), model, commandHistory, expectedMessage);
+    }
+
+    @Test
+    public void execute_corequisitesExistsInDegreePlanner_throwsCommandException() {
+        Module moduleInList = model.getApplication().getModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
+        Module moduleWithInvalidCorequisite = new ModuleBuilder()
+                .withCorequisites(moduleInList.getCode().toString()).build();
+        String expectedMessage = String.format(AddCommand.MESSAGE_EXISTING_COREQUISITES_IN_DEGREE_PLAN,
+                moduleWithInvalidCorequisite.getCode(), moduleInList.getCode());
+        assertCommandFailure(new AddCommand(moduleWithInvalidCorequisite), model, commandHistory, expectedMessage);
+    }
 }

--- a/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/pwe/planner/logic/commands/CommandTestUtil.java
@@ -157,8 +157,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredModuleList().size());
 
         Module module = model.getFilteredModuleList().get(targetIndex.getZeroBased());
-        final String[] splitName = module.getName().fullName.split("\\s+");
-        model.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(splitName[0]));
+        model.updateFilteredModuleList(new NameContainsKeywordsPredicate<>(module.getName().toString()));
 
         assertEquals(1, model.getFilteredModuleList().size());
     }


### PR DESCRIPTION
`add` and `edit` commands have yet to be updated to properly handle
interactions with co-requisite/semesters constraints. This may cause
data integrity of the degree plan to be violated, which may cause the
application to function correctly.

Let's update the `add` and `edit` commands to properly handle
interactions with co-requisite/semesters, and update the tests to ensure
correct behaviour of the commands. Additionally, let's introduce
`StringUtil#joinStreamAsString(...)` helper method to reduce repetitive
code when converting a stream to a delimited string.