### PR TITLE
Logic: Improve `find` command to support tags and semesters

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/FindCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/FindCommand.java
@@ -9,6 +9,7 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.function.Predicate;
 
@@ -31,7 +32,9 @@ public class FindCommand extends Command {
             + "OPERATOR "
             + "[" + PREFIX_CODE + "CODE] "
             + "OPERATOR "
-            + "[" + PREFIX_CREDITS + "CREDITS]\n"
+            + "[" + PREFIX_CREDITS + "CREDITS]"
+            + "OPERATOR "
+            + "[" + PREFIX_TAG + "TAGS]\n"
             + "OPERATOR " + OPERATOR_AND + "for logical \"AND\" operation (both conditions A AND B must match)\n"
             + "OPERATOR " + OPERATOR_OR + " for logical \"OR\" operation (either conditions A OR B must match)\n"
             + "You can also use parenthesis to group what search conditions to evaluate first.\n"

--- a/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
+++ b/src/main/java/pwe/planner/logic/parser/BooleanExpressionParser.java
@@ -5,12 +5,14 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_YEAR;
 import static pwe.planner.logic.parser.Operator.getOperatorFromString;
 import static pwe.planner.logic.parser.ParserUtil.parseCode;
 import static pwe.planner.logic.parser.ParserUtil.parseCredits;
 import static pwe.planner.logic.parser.ParserUtil.parseName;
 import static pwe.planner.logic.parser.ParserUtil.parseSemester;
+import static pwe.planner.logic.parser.ParserUtil.parseTag;
 import static pwe.planner.logic.parser.ParserUtil.parseYear;
 
 import java.util.ArrayDeque;
@@ -26,6 +28,7 @@ import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.KeywordsPredicate;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
+import pwe.planner.model.module.TagContainsKeywordsPredicate;
 import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
 import pwe.planner.model.planner.YearContainsKeywordPredicate;
 
@@ -47,7 +50,6 @@ public class BooleanExpressionParser<T> {
             + "Perhaps you might want to consider providing the criteria to filter?\n" + MESSAGE_TIP;
     public static final String MESSAGE_GENERAL_FAIL = "You might want to double check your filter expression!\n"
             + MESSAGE_TIP;
-
 
     private static final String WHITESPACE = " ";
 
@@ -80,6 +82,9 @@ public class BooleanExpressionParser<T> {
         } else if (prefixes.contains(PREFIX_SEMESTER) && argMultimap.getValue(PREFIX_SEMESTER).isPresent()) {
             String semesterKeyword = parseSemester(argMultimap.getValue(PREFIX_SEMESTER).get()).toString();
             predicate = new SemesterContainsKeywordPredicate<>(semesterKeyword);
+        } else if (prefixes.contains(PREFIX_TAG) && argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            String tagKeyword = parseTag(argMultimap.getValue(PREFIX_TAG).get()).tagName;
+            predicate = new TagContainsKeywordsPredicate<>(tagKeyword);
         } else {
             throw new BooleanParserPredicateException(String.format(MESSAGE_UNABLE_TO_CREATE_PREDICATE, args));
         }

--- a/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
@@ -7,6 +7,7 @@ import static pwe.planner.logic.commands.FindCommand.MESSAGE_USAGE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -26,7 +27,8 @@ public class FindCommandParser implements Parser<FindCommand> {
     private static final List<Prefix> PREFIXES = List.of(
             PREFIX_NAME,
             PREFIX_CODE,
-            PREFIX_CREDITS
+            PREFIX_CREDITS,
+            PREFIX_TAG
     );
 
     /**

--- a/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/FindCommandParser.java
@@ -7,6 +7,7 @@ import static pwe.planner.logic.commands.FindCommand.MESSAGE_USAGE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.List;
@@ -28,7 +29,8 @@ public class FindCommandParser implements Parser<FindCommand> {
             PREFIX_NAME,
             PREFIX_CODE,
             PREFIX_CREDITS,
-            PREFIX_TAG
+            PREFIX_TAG,
+            PREFIX_SEMESTER
     );
 
     /**

--- a/src/main/java/pwe/planner/model/module/TagContainsKeywordsPredicate.java
+++ b/src/main/java/pwe/planner/model/module/TagContainsKeywordsPredicate.java
@@ -1,0 +1,38 @@
+package pwe.planner.model.module;
+
+import static java.util.Objects.requireNonNull;
+import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
+
+import java.util.Set;
+
+import pwe.planner.model.tag.Tag;
+
+/**
+ * Tests that a {@code Module}'s {@code Tag} matches keyword given.
+ */
+public class TagContainsKeywordsPredicate<T> implements KeywordsPredicate<T> {
+    private final String keyword;
+
+    public TagContainsKeywordsPredicate(String keyword) {
+        requireNonNull(keyword);
+
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(T object) {
+        requireNonNull(object);
+        Module module = (Module) object;
+
+        Set<Tag> tags = module.getTags();
+        return tags.stream().anyMatch(tag -> parseKeyword(keyword, tag.tagName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && keyword.equals(((TagContainsKeywordsPredicate) other).keyword)); // state check
+    }
+
+}

--- a/src/main/java/pwe/planner/model/planner/SemesterContainsKeywordPredicate.java
+++ b/src/main/java/pwe/planner/model/planner/SemesterContainsKeywordPredicate.java
@@ -3,7 +3,10 @@ package pwe.planner.model.planner;
 import static java.util.Objects.requireNonNull;
 import static pwe.planner.logic.parser.ParserUtil.parseKeyword;
 
+import java.util.Set;
+
 import pwe.planner.model.module.KeywordsPredicate;
+import pwe.planner.model.module.Module;
 
 /**
  * Tests that a {@code DegreePlanner}'s {@code Semester} matches any of the keyword given.
@@ -20,10 +23,18 @@ public class SemesterContainsKeywordPredicate<T> implements KeywordsPredicate<T>
     @Override
     public boolean test(T object) {
         requireNonNull(object);
-        DegreePlanner degreePlanner = (DegreePlanner) object;
 
-        String semester = degreePlanner.getSemester().toString();
-        return parseKeyword(keyword, semester);
+        if (object instanceof DegreePlanner) {
+            DegreePlanner degreePlanner = (DegreePlanner) object;
+            String semester = degreePlanner.getSemester().toString();
+
+            return parseKeyword(keyword, semester);
+        } else { // we are assuming that only DegreePlanner and Module will be using this method.
+            Module module = (Module) object;
+            Set<Semester> semesters = module.getSemesters();
+
+            return semesters.stream().anyMatch(semester -> parseKeyword(keyword, semester.toString()));
+        }
     }
 
     @Override

--- a/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
@@ -30,6 +30,7 @@ import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
 import pwe.planner.model.module.TagContainsKeywordsPredicate;
+import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
 import pwe.planner.storage.JsonSerializableApplication;
 
 /**
@@ -124,6 +125,16 @@ public class FindCommandTest {
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
         assertEquals(List.of(ALICE, BENSON, DANIEL), model.getFilteredModuleList());
+    }
+
+    @Test
+    public void execute_semKeyword_multipleModulesFound() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 1);
+        SemesterContainsKeywordPredicate<Module> predicate = new SemesterContainsKeywordPredicate<>("4");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredModuleList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(List.of(ALICE), model.getFilteredModuleList());
     }
 
     /**

--- a/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/FindCommandTest.java
@@ -6,7 +6,10 @@ import static org.junit.Assert.assertTrue;
 import static pwe.planner.commons.core.Messages.MESSAGE_MODULES_LISTED_OVERVIEW;
 import static pwe.planner.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlannerList;
+import static pwe.planner.testutil.TypicalModules.ALICE;
+import static pwe.planner.testutil.TypicalModules.BENSON;
 import static pwe.planner.testutil.TypicalModules.CARL;
+import static pwe.planner.testutil.TypicalModules.DANIEL;
 import static pwe.planner.testutil.TypicalModules.ELLE;
 import static pwe.planner.testutil.TypicalModules.FIONA;
 import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
@@ -26,6 +29,7 @@ import pwe.planner.model.module.CodeContainsKeywordsPredicate;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.Module;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
+import pwe.planner.model.module.TagContainsKeywordsPredicate;
 import pwe.planner.storage.JsonSerializableApplication;
 
 /**
@@ -110,6 +114,16 @@ public class FindCommandTest {
         expectedModel.updateFilteredModuleList(predicate);
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
         assertEquals(List.of(FIONA), model.getFilteredModuleList());
+    }
+
+    @Test
+    public void execute_tagKeyword_multipleModulesFound() {
+        String expectedMessage = String.format(MESSAGE_MODULES_LISTED_OVERVIEW, 3);
+        TagContainsKeywordsPredicate<Module> predicate = new TagContainsKeywordsPredicate<>("friends");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredModuleList(predicate);
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(List.of(ALICE, BENSON, DANIEL), model.getFilteredModuleList());
     }
 
     /**

--- a/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -23,6 +24,7 @@ import pwe.planner.model.module.Credits;
 import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.Name;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
+import pwe.planner.model.module.TagContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -57,6 +59,10 @@ public class FindCommandParserTest {
                 new FindCommand(new CreditsContainsKeywordsPredicate<>("999"));
         // single keyword
         assertParseSuccess(parser, PREFIX_CREDITS + "999", expectedFindCreditsCommand);
+
+        // single keyword
+        FindCommand expectedFindTagsCommand = new FindCommand(new TagContainsKeywordsPredicate<>("tag"));
+        assertParseSuccess(parser, PREFIX_TAG + "tag", expectedFindTagsCommand);
     }
 
     @Test
@@ -71,6 +77,8 @@ public class FindCommandParserTest {
         // credits/CREDITS || credits/CREDITS
         assertParserSuccess(parser, PREFIX_CREDITS + "4 " + WHITESPACE + OPERATOR_OR + WHITESPACE
                 + PREFIX_CREDITS + "999");
+        // tag/TAGG || tag/Tag1
+        assertParserSuccess(parser, PREFIX_TAG + "TAGG " + OPERATOR_OR + PREFIX_TAG + "Tag1");
 
         // test for boolean AND
         // name/NAME && name/NAME
@@ -82,6 +90,9 @@ public class FindCommandParserTest {
         // credits/CREDITS && credits/CREDITS
         assertParserSuccess(parser, PREFIX_CREDITS + "4 " + WHITESPACE + OPERATOR_AND + WHITESPACE
                 + PREFIX_CREDITS + "999");
+        // tag/TAG && tag/TAG
+        assertParserSuccess(parser, PREFIX_TAG + "TAG " + WHITESPACE + OPERATOR_AND + WHITESPACE
+                + PREFIX_TAG + "TAGGG");
 
         // test for boolean AND and boolean OR
         // credits/CREDITS || credits/CREDITS && name/Programming
@@ -91,6 +102,14 @@ public class FindCommandParserTest {
         // credits/4 || (name/Information && name/Security)
         assertParserSuccess(parser, PREFIX_CREDITS + "4" + OPERATOR_OR + OPERATOR_LEFT_BRACKET + PREFIX_NAME
                 + "information" + OPERATOR_AND + PREFIX_NAME + "security" + OPERATOR_RIGHT_BRACKET);
+
+        // tag/C || (name/Information && name/Security)
+        assertParserSuccess(parser, PREFIX_TAG + "C" + OPERATOR_OR + OPERATOR_LEFT_BRACKET + PREFIX_NAME
+                + "information" + OPERATOR_AND + PREFIX_NAME + "security" + OPERATOR_RIGHT_BRACKET);
+
+        // tag/C && (name/Information || name/Security)
+        assertParserSuccess(parser, PREFIX_TAG + "C" + OPERATOR_AND + OPERATOR_LEFT_BRACKET + PREFIX_NAME
+                + "information" + OPERATOR_OR + PREFIX_NAME + "security" + OPERATOR_RIGHT_BRACKET);
 
     }
 

--- a/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,7 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static pwe.planner.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -25,6 +26,7 @@ import pwe.planner.model.module.CreditsContainsKeywordsPredicate;
 import pwe.planner.model.module.Name;
 import pwe.planner.model.module.NameContainsKeywordsPredicate;
 import pwe.planner.model.module.TagContainsKeywordsPredicate;
+import pwe.planner.model.planner.SemesterContainsKeywordPredicate;
 
 public class FindCommandParserTest {
 
@@ -63,6 +65,9 @@ public class FindCommandParserTest {
         // single keyword
         FindCommand expectedFindTagsCommand = new FindCommand(new TagContainsKeywordsPredicate<>("tag"));
         assertParseSuccess(parser, PREFIX_TAG + "tag", expectedFindTagsCommand);
+
+        FindCommand expectedFindSemesterCommand = new FindCommand(new SemesterContainsKeywordPredicate<>("2"));
+        assertParseSuccess(parser, PREFIX_SEMESTER + "2", expectedFindSemesterCommand);
     }
 
     @Test
@@ -79,6 +84,8 @@ public class FindCommandParserTest {
                 + PREFIX_CREDITS + "999");
         // tag/TAGG || tag/Tag1
         assertParserSuccess(parser, PREFIX_TAG + "TAGG " + OPERATOR_OR + PREFIX_TAG + "Tag1");
+        // sem/1 || sem/2
+        assertParserSuccess(parser, PREFIX_SEMESTER + "1 " + OPERATOR_OR + PREFIX_SEMESTER + "2");
 
         // test for boolean AND
         // name/NAME && name/NAME
@@ -93,6 +100,8 @@ public class FindCommandParserTest {
         // tag/TAG && tag/TAG
         assertParserSuccess(parser, PREFIX_TAG + "TAG " + WHITESPACE + OPERATOR_AND + WHITESPACE
                 + PREFIX_TAG + "TAGGG");
+        // sem1 && sem/2
+        assertParserSuccess(parser, PREFIX_SEMESTER + "1" + OPERATOR_AND + PREFIX_SEMESTER + "2");
 
         // test for boolean AND and boolean OR
         // credits/CREDITS || credits/CREDITS && name/Programming

--- a/src/test/java/pwe/planner/model/module/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/pwe/planner/model/module/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,64 @@
+package pwe.planner.model.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import pwe.planner.testutil.ModuleBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateKeyword = "first";
+        String secondPredicateKeyword = "second";
+
+        TagContainsKeywordsPredicate<Module> firstPredicate = new TagContainsKeywordsPredicate<>(
+                firstPredicateKeyword);
+        TagContainsKeywordsPredicate<Module> secondPredicate = new TagContainsKeywordsPredicate<>(
+                secondPredicateKeyword);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate<Module> firstPredicateCopy = new TagContainsKeywordsPredicate<>(
+                firstPredicateKeyword);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different module -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate<Module> predicate = new TagContainsKeywordsPredicate<>("tag");
+        assertTrue(predicate.test(new ModuleBuilder().withTags("tag").build()));
+
+        // Mixed-case keywords
+        predicate = new TagContainsKeywordsPredicate<>("tAg");
+        assertTrue(predicate.test(new ModuleBuilder().withTags("tag").build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+
+
+        // Non-matching keyword
+        TagContainsKeywordsPredicate<Module> predicate = new TagContainsKeywordsPredicate<>("notExisting");
+        assertFalse(predicate.test(new ModuleBuilder().withTags("tags").build()));
+
+        // Keywords match credits but does not match tag
+        predicate = new TagContainsKeywordsPredicate<>("123");
+        assertFalse(predicate.test(new ModuleBuilder().withTags("Alice").withCredits("123")
+                .withCode("CS1010").withTags("TAG").build()));
+    }
+}

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -15,6 +15,8 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
+import static pwe.planner.testutil.TypicalModules.ALICE;
 import static pwe.planner.testutil.TypicalModules.BENSON;
 import static pwe.planner.testutil.TypicalModules.CARL;
 import static pwe.planner.testutil.TypicalModules.DANIEL;
@@ -169,6 +171,24 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
 
         /* Case: find module in application, code is substring of keyword -> 0 modules found */
         command = FindCommand.COMMAND_WORD + " " + PREFIX_CODE + "FS4205"; // valid partial code derived from IFS4205
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find code of module in application with correct PREFIX -> 3 module found */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_TAG + "friends";
+        ModelHelper.setFilteredList(expectedModel, ALICE, BENSON, DANIEL);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find non-existent module in application with PREFIX_TAG -> 0 modules found */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_TAG + "NotExisting";
+        ModelHelper.setFilteredList(expectedModel);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
+        /* Case: find module in application with PREFIX_TAG, keyword is substring of a valid tag -> 0 modules found */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_TAG + "frie"; // derived from friends
+        ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -15,11 +15,13 @@ import static pwe.planner.logic.parser.CliSyntax.OPERATOR_RIGHT_BRACKET;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_CREDITS;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
+import static pwe.planner.logic.parser.CliSyntax.PREFIX_SEMESTER;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_TAG;
 import static pwe.planner.testutil.TypicalModules.ALICE;
 import static pwe.planner.testutil.TypicalModules.BENSON;
 import static pwe.planner.testutil.TypicalModules.CARL;
 import static pwe.planner.testutil.TypicalModules.DANIEL;
+import static pwe.planner.testutil.TypicalModules.ELLE;
 import static pwe.planner.testutil.TypicalModules.KEYWORD_MATCHING_MEIER;
 
 import java.util.ArrayList;
@@ -198,6 +200,12 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
+        /* Case: find module in the application with PREFIX_SEM/4 -> 2 modules found */
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_SEMESTER + "4";
+        ModelHelper.setFilteredList(expectedModel, ALICE);
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+
         /* Case: find while a module is selected -> selected card deselected */
         showAllModules();
         selectModule(Index.fromOneBased(1));
@@ -297,6 +305,11 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
         expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
+
+        command = FindCommand.COMMAND_WORD + " " + PREFIX_SEMESTER + "4" + OPERATOR_AND + " " + PREFIX_SEMESTER
+                + "2";
+        ModelHelper.setFilteredList(expectedModel, ALICE);
+        assertCommandSuccess(command, expectedModel);
     }
 
     @Test
@@ -308,6 +321,12 @@ public class FindCommandSystemTest extends ApplicationSystemTest {
                         + PREFIX_NAME + "Meier " + OPERATOR_RIGHT_BRACKET;
         Model expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, DANIEL, CARL);
+        assertCommandSuccess(command, expectedModel);
+
+        /* find (sem/1 || sem/2) && credits/4 -> Return 1 module */
+        command = FindCommand.COMMAND_WORD + " " + OPERATOR_LEFT_BRACKET + PREFIX_SEMESTER + "1" + OPERATOR_OR
+                + PREFIX_SEMESTER + "2" + OPERATOR_RIGHT_BRACKET + OPERATOR_AND + PREFIX_CREDITS + "4";
+        ModelHelper.setFilteredList(expectedModel, ELLE);
         assertCommandSuccess(command, expectedModel);
     }
 


### PR DESCRIPTION
Resolves #203 

The find command only supports mainly the module's name, code and its credits.
A user would expect most of the module's attributes to be searchable.

Let's update the `find` command to support `tags` and `semesters` and:
* include units tests to ensure our behaviour of the `find` command