### PR TITLE
Tests: add tests for `RequirementCategory`-related classes

### DIFF
--- a/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.logic.commands.exceptions.CommandException;
 import pwe.planner.model.Model;
@@ -92,8 +93,7 @@ public class RequirementAddCommand extends Command {
                 .collect(Collectors.toList());
 
         if (!nonExistentCodes.isEmpty()) {
-            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
-                    .collect(Collectors.joining(", "));
+            String nonExistentCodesErrorMessage = StringUtil.joinStreamAsString(nonExistentCodes.stream().sorted());
             throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
         }
 
@@ -120,7 +120,7 @@ public class RequirementAddCommand extends Command {
         model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         model.commitApplication();
 
-        String codesAdded = toAdd.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String codesAdded = StringUtil.joinStreamAsString(toAdd.stream().sorted());
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, codesAdded, currentRequirementCategory.getName()));
     }

--- a/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementAddCommand.java
@@ -6,7 +6,9 @@ import static pwe.planner.logic.parser.CliSyntax.PREFIX_CODE;
 import static pwe.planner.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import pwe.planner.logic.CommandHistory;
@@ -23,23 +25,45 @@ public class RequirementAddCommand extends Command {
 
     public static final String COMMAND_WORD = "requirement_add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to a requirement category.\n"
-            + "Parameters: "
+    // This is declared before MESSAGE_USAGE to prevent illegal forward reference
+    public static final String FORMAT_AND_EXAMPLES = "Format: " + COMMAND_WORD + ' '
             + PREFIX_NAME + "NAME "
+            + PREFIX_CODE + "CODE "
             + "[" + PREFIX_CODE + "CODE]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "IT Professionalism "
-            + PREFIX_CODE + "IS4231 ";
+            + PREFIX_NAME + "Computing Foundation "
+            + PREFIX_CODE + "CS1010";
 
-    public static final String MESSAGE_SUCCESS = "Module added to requirement category: %1$s";
+    // General command help details
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to a requirement category.\n"
+            + FORMAT_AND_EXAMPLES;
+
+    // Command success message
+    public static final String MESSAGE_SUCCESS = "Successfully added module(s) (%1$s) the requirement category %2$s!";
+
+    // Command failure messages
     public static final String MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY =
-            "The requirement category (%1$s) does not exist!";
-    public static final String MESSAGE_NONEXISTENT_CODE =
-            "The module to be added to the requirement category does not exists in the module list!";
+            "You cannot specify a requirement category (%1$s) that does not exist!\n"
+            + "Perhaps you misspelled the name of the requirement category?\n"
+            + "[Tip] You may want to refer to the requirement category list to see the requirement categories"
+            + " in the application using the \"requirement_list\" command!";
+
+    public static final String MESSAGE_NONEXISTENT_CODE = "You cannot specify module(s) (%1$s) that does not exist!\n"
+            + "Perhaps you were trying to add modules into the application?\n"
+            + "[Tip] You may want to add the module into the module list first using the \"add\" command.\n"
+            + "Afterwards, you can add the module into the requirement category using the "
+            + "\"requirement_add\" command!";
+
     public static final String MESSAGE_DUPLICATE_CODE =
-            "The module has already been added to %1$s ";
+            "The module has already been added to requirement category %1$s\n"
+            + "Perhaps you misspelled a module code?\n"
+            + "[Tip] You are able to view all the modules in application using the \"list\" command.";
+
     public static final String MESSAGE_EXISTING_CODE =
-            "The module to be added already exists in another requirement category!";
+            "The module to be added already exists in another requirement category!\n"
+            + "Perhaps you misspelled a module code?\n"
+            + "[Tip] You may want to refer to the requirement category list to see the requirement categories"
+            + " in the application using the \"requirement_list\" command!";
 
     private final Name toFind;
     private final Set<Code> toAdd = new HashSet<>();
@@ -64,8 +88,13 @@ public class RequirementAddCommand extends Command {
             throw new CommandException(String.format(MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY, toFind));
         }
 
-        if (toAdd.stream().anyMatch(code -> !model.hasModuleCode(code))) {
-            throw new CommandException(MESSAGE_NONEXISTENT_CODE);
+        List<Code> nonExistentCodes = toAdd.stream().filter(code -> !model.hasModuleCode(code))
+                .collect(Collectors.toList());
+
+        if (!nonExistentCodes.isEmpty()) {
+            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
+                    .collect(Collectors.joining(", "));
+            throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
         }
 
         if (currentRequirementCategory.hasModuleCode(toAdd)) {
@@ -90,7 +119,10 @@ public class RequirementAddCommand extends Command {
         );
         model.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         model.commitApplication();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, currentRequirementCategory.getName()));
+
+        String codesAdded = toAdd.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, codesAdded, currentRequirementCategory.getName()));
     }
 
     @Override

--- a/src/main/java/pwe/planner/logic/commands/RequirementMoveCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementMoveCommand.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.logic.commands.exceptions.CommandException;
 import pwe.planner.model.Model;
@@ -93,8 +94,7 @@ public class RequirementMoveCommand extends Command {
                 .collect(Collectors.toList());
 
         if (!nonExistentCodes.isEmpty()) {
-            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
-                    .collect(Collectors.joining(", "));
+            String nonExistentCodesErrorMessage = StringUtil.joinStreamAsString(nonExistentCodes.stream().sorted());
             throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
         }
 
@@ -103,8 +103,8 @@ public class RequirementMoveCommand extends Command {
                 .contains(code))).collect(Collectors.toList());
 
         if (!codeNotInAnyRequirementCategory.isEmpty()) {
-            String codeNotInAnyRequirementCategoryErrorMessage = codeNotInAnyRequirementCategory.stream()
-                    .map(Code::toString).collect(Collectors.joining(", "));
+            String codeNotInAnyRequirementCategoryErrorMessage =
+                    StringUtil.joinStreamAsString(codeNotInAnyRequirementCategory.stream().sorted());
             throw new CommandException(String.format(MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
                     codeNotInAnyRequirementCategoryErrorMessage));
         }
@@ -146,7 +146,7 @@ public class RequirementMoveCommand extends Command {
             }
         }
 
-        String codesMoved = toMove.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String codesMoved = StringUtil.joinStreamAsString(toMove.stream().sorted());
 
         model.commitApplication();
         return new CommandResult(String.format(MESSAGE_SUCCESS, codesMoved, destinationRequirementCategory.getName()));

--- a/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
+++ b/src/main/java/pwe/planner/logic/commands/RequirementRemoveCommand.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.logic.commands.exceptions.CommandException;
 import pwe.planner.model.Model;
@@ -68,8 +69,8 @@ public class RequirementRemoveCommand extends Command {
                 .collect(Collectors.toList());
 
         if (!nonExistentCodes.isEmpty()) {
-            String nonExistentCodesErrorMessage = nonExistentCodes.stream().map(Code::toString)
-                    .collect(Collectors.joining(", "));
+            String nonExistentCodesErrorMessage =
+                    StringUtil.joinStreamAsString(nonExistentCodes.stream().sorted());
             throw new CommandException(String.format(MESSAGE_NONEXISTENT_CODE, nonExistentCodesErrorMessage));
         }
 
@@ -78,8 +79,8 @@ public class RequirementRemoveCommand extends Command {
                         .contains(code))).collect(Collectors.toList());
 
         if (!codeNotInAnyRequirementCategory.isEmpty()) {
-            String codeNotInAnyRequirementCategoryErrorMessage = codeNotInAnyRequirementCategory.stream()
-                    .map(Code::toString).collect(Collectors.joining(", "));
+            String codeNotInAnyRequirementCategoryErrorMessage =
+                    StringUtil.joinStreamAsString(codeNotInAnyRequirementCategory.stream().sorted());
             throw new CommandException(String.format(MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
                     codeNotInAnyRequirementCategoryErrorMessage));
         }
@@ -115,7 +116,7 @@ public class RequirementRemoveCommand extends Command {
             }
         }
 
-        String codesMoved = toRemove.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String codesMoved = StringUtil.joinStreamAsString(toRemove.stream().sorted());
 
         model.commitApplication();
         return new CommandResult(String.format(MESSAGE_SUCCESS, codesMoved));

--- a/src/main/java/pwe/planner/logic/parser/RequirementAddCommandParser.java
+++ b/src/main/java/pwe/planner/logic/parser/RequirementAddCommandParser.java
@@ -28,6 +28,10 @@ public class RequirementAddCommandParser implements Parser<RequirementAddCommand
     public RequirementAddCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
+        if (args.isEmpty()) {
+            throw new ParseException(RequirementAddCommand.MESSAGE_USAGE);
+        }
+
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CODE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CODE) || !argMultimap.getPreamble().isEmpty()) {

--- a/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
@@ -10,7 +10,6 @@ import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequir
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -18,6 +17,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
@@ -61,7 +61,7 @@ public class RequirementAddCommandTest {
     public void execute_nonExistentCode_throwsCommandException() {
         Set<Code> validCodeSet = Set.of(new Code("CS2010"));
         Name requirementCategoryName = new Name("Computing Foundation");
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
                 String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
 
@@ -114,7 +114,7 @@ public class RequirementAddCommandTest {
         expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         expectedModel.commitApplication();
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
                 String.format(RequirementAddCommand.MESSAGE_SUCCESS, formattedCodeString, requirementCategoryName),
@@ -142,7 +142,7 @@ public class RequirementAddCommandTest {
         expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         expectedModel.commitApplication();
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
                 String.format(RequirementAddCommand.MESSAGE_SUCCESS, formattedCodeString,

--- a/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementAddCommandTest.java
@@ -10,6 +10,7 @@ import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequir
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,7 +34,6 @@ public class RequirementAddCommandTest {
 
     private CommandHistory commandHistory = new CommandHistory();
     private Model model;
-    private Set<Code> codeList = new HashSet<>();
 
     @Before
     public void setUp() throws IllegalValueException {
@@ -50,73 +50,74 @@ public class RequirementAddCommandTest {
 
     @Test
     public void execute_nonExistentRequirementCategory_throwsCommandException() {
-        codeList.clear();
+        Set<Code> validCodeSet = new HashSet<>();
         Name nonExistentRequirementCategoryName = new Name("DOES NOT EXIST");
-        assertCommandFailure(new RequirementAddCommand(nonExistentRequirementCategoryName, codeList),
+        assertCommandFailure(new RequirementAddCommand(nonExistentRequirementCategoryName, validCodeSet),
                 model, commandHistory, String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_REQUIREMENT_CATEGORY,
                         nonExistentRequirementCategoryName));
     }
 
     @Test
     public void execute_nonExistentCode_throwsCommandException() {
-        codeList.clear();
-        codeList.add(new Code("CS2010"));
+        Set<Code> validCodeSet = Set.of(new Code("CS2010"));
         Name requirementCategoryName = new Name("Computing Foundation");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                RequirementAddCommand.MESSAGE_NONEXISTENT_CODE);
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
 
         //case insensitive checks
         requirementCategoryName = new Name("comPUTING FOUNDATion");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_CODE,
-                        requirementCategoryName));
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
     }
 
     @Test
     public void execute_duplicateCode_throwsCommandException() {
-        codeList.clear();
-        codeList.add(new Code("CS2100"));
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Foundation");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
-                        requirementCategoryName));
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE, requirementCategoryName));
 
         //case insensitive checks
+        Set<Code> validCodeSetCaseInsensitive = Set.of(new Code("CS2100"));
         Name requirementCategoryNameInsensitive = new Name("COMPUting FOundAtIon");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryNameInsensitive, codeList), model,
-                commandHistory, String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryNameInsensitive, validCodeSetCaseInsensitive),
+                model, commandHistory, String.format(RequirementAddCommand.MESSAGE_DUPLICATE_CODE,
                         requirementCategoryName));
     }
 
     @Test
     public void execute_existingCode_throwsCommandException() {
-        codeList.clear();
-        codeList.add(new Code("CS2100"));
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Breadth");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
                 RequirementAddCommand.MESSAGE_EXISTING_CODE);
 
         //case insensitive checks
+        Set<Code> validCodeSetCaseInsensitive = Set.of(new Code("CS2100"));
         requirementCategoryName = new Name("COMPUting BREAdth");
-        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                String.format(RequirementAddCommand.MESSAGE_EXISTING_CODE,
+        assertCommandFailure(new RequirementAddCommand(requirementCategoryName, validCodeSetCaseInsensitive),
+                model, commandHistory, String.format(RequirementAddCommand.MESSAGE_EXISTING_CODE,
                         requirementCategoryName));
     }
 
     @Test
     public void execute_addModuleToRequirementCategory_success() {
-        codeList.clear();
+        Set<Code> validCodeSet = Set.of(new Code("CS2040C"));
+        Set<Code> codeSetToCheck = Set.of(new Code("CS2040C"), new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Foundation");
         RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
-        RequirementCategory editedRequirementCategory =
-                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+        RequirementCategory editedRequirementCategory = new RequirementCategory(requirementCategoryName,
+                currentRequirementCategory.getCredits(), codeSetToCheck);
 
-        Model expectedModel = model;
+        Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
         expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         expectedModel.commitApplication();
 
-        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                String.format(RequirementAddCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_SUCCESS, formattedCodeString, requirementCategoryName),
                 expectedModel);
 
         // undo -> reverts application back to previous state
@@ -130,41 +131,42 @@ public class RequirementAddCommandTest {
 
     @Test
     public void execute_addModuleToRequirementCategoryCaseInsensitive_success() {
-        codeList.clear();
-        Name requirementCategoryName = new Name("CoMpUtInG BreaDTH");
+        Set<Code> validCodeSet = Set.of(new Code("CS2102"), new Code("CS2040C"));
+        Set<Code> codeSetToCheck = Set.of(new Code("CS2040C"), new Code("CS2100"), new Code("CS2102"));
+        Name requirementCategoryName = new Name("CoMpUtInG FoundatioN");
         RequirementCategory currentRequirementCategory = model.getRequirementCategory(requirementCategoryName);
-        RequirementCategory editedRequirementCategory =
-                new RequirementCategory(requirementCategoryName, currentRequirementCategory.getCredits(), codeList);
+        RequirementCategory editedRequirementCategory = new RequirementCategory(currentRequirementCategory.getName(),
+                currentRequirementCategory.getCredits(), codeSetToCheck);
 
-        Model expectedModel = model;
+        Model expectedModel = new ModelManager(model.getApplication(), new UserPrefs());
         expectedModel.setRequirementCategory(currentRequirementCategory, editedRequirementCategory);
         expectedModel.commitApplication();
 
-        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, codeList), model, commandHistory,
-                String.format(RequirementAddCommand.MESSAGE_SUCCESS, requirementCategoryName, codeList),
-                expectedModel);
+        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+
+        assertCommandSuccess(new RequirementAddCommand(requirementCategoryName, validCodeSet), model, commandHistory,
+                String.format(RequirementAddCommand.MESSAGE_SUCCESS, formattedCodeString,
+                        currentRequirementCategory.getName()), expectedModel);
 
     }
 
     @Test
     public void execute_equals() {
-        codeList.clear();
-        codeList.add(new Code("CS2100"));
+        Set<Code> validCodeSet = Set.of(new Code("CS2100"));
         Name requirementCategoryName = new Name("Computing Foundation");
 
-        Set<Code> codeListToCompare = new HashSet<>();
-        codeListToCompare.add(new Code("CS1010"));
+        Set<Code> codeSetToCompare = Set.of(new Code("CS1010"));
         Name requirementCategoryNameToCompare = new Name("Mathematics");
 
-        RequirementAddCommand commandBaseline = new RequirementAddCommand(requirementCategoryName, codeList);
+        RequirementAddCommand commandBaseline = new RequirementAddCommand(requirementCategoryName, validCodeSet);
         RequirementAddCommand commandToCompare =
-                new RequirementAddCommand(requirementCategoryNameToCompare, codeListToCompare);
+                new RequirementAddCommand(requirementCategoryNameToCompare, codeSetToCompare);
 
         //same object -> returns true
         assertTrue(commandBaseline.equals(commandBaseline));
 
         //different objects, same values -> returns true
-        RequirementAddCommand commandBaselineCopy = new RequirementAddCommand(requirementCategoryName, codeList);
+        RequirementAddCommand commandBaselineCopy = new RequirementAddCommand(requirementCategoryName, validCodeSet);
         assertTrue(commandBaseline.equals(commandBaselineCopy));
 
         //different objects -> returns false

--- a/src/test/java/pwe/planner/logic/commands/RequirementListCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementListCommandTest.java
@@ -5,18 +5,16 @@ import static pwe.planner.testutil.TypicalDegreePlanners.getTypicalDegreePlanner
 import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
 import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
 
-import java.util.stream.Collectors;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import javafx.collections.ObservableList;
 import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
 import pwe.planner.model.UserPrefs;
-import pwe.planner.model.module.Code;
 import pwe.planner.model.requirement.RequirementCategory;
 import pwe.planner.storage.JsonSerializableApplication;
 
@@ -50,8 +48,8 @@ public class RequirementListCommandTest {
             if (requirementCategory.getCodeSet().isEmpty()) {
                 requirementListContent.append("No modules added!");
             } else {
-                requirementListContent.append("Modules: ").append(requirementCategory.getCodeSet().stream()
-                        .map(Code::toString).sorted().collect(Collectors.joining(", ")));
+                requirementListContent.append("Modules: ")
+                        .append(StringUtil.joinStreamAsString(requirementCategory.getCodeSet().stream().sorted()));
             }
 
             requirementListContent.append("\n\n");

--- a/src/test/java/pwe/planner/logic/commands/RequirementMoveCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementMoveCommandTest.java
@@ -9,7 +9,6 @@ import static pwe.planner.testutil.TypicalModules.getTypicalModuleList;
 import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequirementCategoriesList;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -17,6 +16,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
@@ -69,7 +69,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(requirementCategoryName, validCodeSet);
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
 
@@ -84,7 +84,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(requirementCategoryName, validCodeSet);
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         String expectedMessage =
                 String.format(RequirementMoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY, formattedCodeString);
@@ -102,7 +102,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(requirementCategoryName, validCodeSet);
 
-        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(invalidCodeSet.stream().sorted());
 
         String expectedMessage =
                 String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
@@ -120,7 +120,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(requirementCategoryName, validCodeSet);
 
-        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(invalidCodeSet.stream().sorted());
 
         String expectedMessage =
                 String.format(RequirementMoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY, formattedCodeString);
@@ -167,7 +167,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(requirementCategoryName, validCodeSet);
 
-        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(invalidCodeSet.stream().sorted());
 
         String expectedMessage = String.format(RequirementMoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString);
 
@@ -208,7 +208,7 @@ public class RequirementMoveCommandTest {
         expectedModel.setRequirementCategory(destinationReqCat, editedDestinationReqCat);
         expectedModel.commitApplication();
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(destinationReqCatName, validCodeSet);
@@ -227,7 +227,7 @@ public class RequirementMoveCommandTest {
 
         Model expectedModel = model;
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(destinationReqCatName, validCodeSet);
@@ -270,7 +270,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(destinationReqCatName, validCodeSet);
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         String expectedMessage =
                 String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString, destinationReqCatName);
@@ -311,7 +311,7 @@ public class RequirementMoveCommandTest {
         RequirementMoveCommand requirementMoveCommand =
                 new RequirementMoveCommand(destinationReqCatName, validCodeSet);
 
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
 
         String expectedMessage =
                 String.format(RequirementMoveCommand.MESSAGE_SUCCESS, formattedCodeString, destinationReqCatName);

--- a/src/test/java/pwe/planner/logic/commands/RequirementRemoveCommandTest.java
+++ b/src/test/java/pwe/planner/logic/commands/RequirementRemoveCommandTest.java
@@ -10,7 +10,6 @@ import static pwe.planner.testutil.TypicalRequirementCategories.getTypicalRequir
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -18,6 +17,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import pwe.planner.commons.exceptions.IllegalValueException;
+import pwe.planner.commons.util.StringUtil;
 import pwe.planner.logic.CommandHistory;
 import pwe.planner.model.Model;
 import pwe.planner.model.ModelManager;
@@ -50,14 +50,13 @@ public class RequirementRemoveCommandTest {
     @Test
     public void execute_nonExistentCode_throwsCommandException() {
         Set<Code> validCodeSet = Set.of(new Code("CS9999"));
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
 
         //case insensitive checks
         Set<Code> validCodeSetCaseInsensitive = Set.of(new Code("cs9999"));
-        formattedCodeString = validCodeSetCaseInsensitive.stream().map(Code::toString)
-                .collect(Collectors.joining(", "));
+        formattedCodeString = StringUtil.joinStreamAsString(validCodeSetCaseInsensitive.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
     }
@@ -66,7 +65,7 @@ public class RequirementRemoveCommandTest {
     public void execute_nonExistentCodes_throwsCommandException() {
         Set<Code> invalidCodeSet = Set.of(new Code("CS9999"));
         Set<Code> validCodeSet = Set.of(new Code("CS2100"), new Code("CS9999"));
-        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(invalidCodeSet.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_NONEXISTENT_CODE, formattedCodeString));
     }
@@ -74,15 +73,14 @@ public class RequirementRemoveCommandTest {
     @Test
     public void execute_codeNotInAnyRequirementCategory_throwsCommandException() {
         Set<Code> validCodeSet = Set.of(new Code("CS1010"));
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
                         formattedCodeString));
 
         //case insensitive checks
         Set<Code> validCodeSetCaseInsensitive = Set.of(new Code("cs1010"));
-        formattedCodeString = validCodeSetCaseInsensitive.stream().map(Code::toString)
-                .collect(Collectors.joining(", "));
+        formattedCodeString = StringUtil.joinStreamAsString(validCodeSetCaseInsensitive.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSetCaseInsensitive), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
                         formattedCodeString));
@@ -92,7 +90,7 @@ public class RequirementRemoveCommandTest {
     public void execute_codesNotInAnyRequirementCategory_throwsCommandException() {
         Set<Code> invalidCodeSet = Set.of(new Code("CS1010"));
         Set<Code> validCodeSet = Set.of(new Code("CS2100"), new Code("CS1010"));
-        String formattedCodeString = invalidCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(invalidCodeSet.stream().sorted());
         assertCommandFailure(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_CODE_NOT_IN_ANY_REQUIREMENT_CATEGORY,
                         formattedCodeString));
@@ -111,7 +109,7 @@ public class RequirementRemoveCommandTest {
         expectedModel.commitApplication();
 
         validCodeSet.add(new Code("CS2100"));
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandSuccess(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_SUCCESS, formattedCodeString),
                 expectedModel);
@@ -130,7 +128,7 @@ public class RequirementRemoveCommandTest {
         expectedModel.commitApplication();
 
         validCodeSet.add(new Code("cs2100"));
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandSuccess(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_SUCCESS, formattedCodeString),
                 expectedModel);
@@ -156,7 +154,7 @@ public class RequirementRemoveCommandTest {
         expectedModel.commitApplication();
 
         validCodeSet.addAll(Set.of(new Code("CS2100"), new Code("CS1231")));
-        String formattedCodeString = validCodeSet.stream().map(Code::toString).collect(Collectors.joining(", "));
+        String formattedCodeString = StringUtil.joinStreamAsString(validCodeSet.stream().sorted());
         assertCommandSuccess(new RequirementRemoveCommand(validCodeSet), model, commandHistory,
                 String.format(RequirementRemoveCommand.MESSAGE_SUCCESS, formattedCodeString),
                 expectedModel);

--- a/src/test/java/pwe/planner/logic/parser/RequirementAddCommandParserTest.java
+++ b/src/test/java/pwe/planner/logic/parser/RequirementAddCommandParserTest.java
@@ -22,6 +22,12 @@ public class RequirementAddCommandParserTest {
     private RequirementAddCommandParser parser = new RequirementAddCommandParser();
 
     @Test
+    public void parse_nullValue_failure() {
+        //empty input
+        assertParseFailure(parser, "", RequirementAddCommand.MESSAGE_USAGE);
+    }
+
+    @Test
     public void parse_invalidValue_failure() {
         // invalid format
         assertParseFailure(parser, " INVALID INPUT", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -56,6 +62,9 @@ public class RequirementAddCommandParserTest {
                 new RequirementAddCommand(validName, validCodeSet);
 
         assertParseSuccess(parser, " " + PREFIX_NAME + "Computing Foundation " + PREFIX_CODE + "CS1010 ",
+                expectedRequirementAddCommand);
+
+        assertParseSuccess(parser, " " + PREFIX_CODE + "CS1010 " + PREFIX_NAME + "Computing Foundation ",
                 expectedRequirementAddCommand);
 
         // whitespace only preamble

--- a/src/test/java/pwe/planner/model/requirement/RequirementCategoryTest.java
+++ b/src/test/java/pwe/planner/model/requirement/RequirementCategoryTest.java
@@ -1,0 +1,88 @@
+package pwe.planner.model.requirement;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.testutil.TypicalRequirementCategories.COMPUTING_BREADTH;
+import static pwe.planner.testutil.TypicalRequirementCategories.COMPUTING_FOUNDATION;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import pwe.planner.testutil.RequirementCategoryBuilder;
+
+public class RequirementCategoryTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void asObservableList_modifyList_throwsUnsupportedOperationException() {
+        RequirementCategory requirementCategory = new RequirementCategoryBuilder().build();
+        thrown.expect(UnsupportedOperationException.class);
+        requirementCategory.getCodeSet().remove(0);
+    }
+
+    @Test
+    public void isSameRequirementCategory() {
+        // same object -> true
+        assertTrue(COMPUTING_FOUNDATION.isSameRequirementCategory(COMPUTING_FOUNDATION));
+
+        // null -> false
+        assertFalse(COMPUTING_FOUNDATION.isSameRequirementCategory(null));
+
+        // different name, credits and code -> false
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategoryBuilder().withName("DIFFERENT").withCredits("14").withCodes("CS9999").build();
+        assertFalse(COMPUTING_FOUNDATION.isSameRequirementCategory(editedRequirementCategory));
+
+        // different name, credits and same code -> false
+        editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withName("DIFFERENT").withCredits("14").build();
+        assertFalse(COMPUTING_FOUNDATION.isSameRequirementCategory(editedRequirementCategory));
+
+        // different name, code and same credits -> false
+        editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withName("DIFFERENT").withCodes("CS1231").build();
+        assertFalse(COMPUTING_FOUNDATION.isSameRequirementCategory(editedRequirementCategory));
+
+        // different name and same code, credits -> false
+        editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withName("DIFFERENT").build();
+        assertFalse(COMPUTING_FOUNDATION.isSameRequirementCategory(editedRequirementCategory));
+
+        // different credits, code and same name -> false
+        editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withCredits("14").withCodes("CS9999").build();
+        assertTrue(COMPUTING_FOUNDATION.isSameRequirementCategory(editedRequirementCategory));
+    }
+
+    @Test
+    public void equals() {
+        // same values -> true
+        RequirementCategory requirementCategoryCopy = new RequirementCategoryBuilder(COMPUTING_FOUNDATION).build();
+        assertTrue(COMPUTING_FOUNDATION.equals(requirementCategoryCopy));
+
+        // same object -> true
+        assertTrue(COMPUTING_FOUNDATION.equals(COMPUTING_FOUNDATION));
+
+        // different type -> false
+        assertFalse(COMPUTING_FOUNDATION.equals(3));
+
+        // different requirement category -> false
+        assertFalse(COMPUTING_FOUNDATION.equals(COMPUTING_BREADTH));
+
+        // different name -> false
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withName("DIFFERENT").build();
+        assertFalse(COMPUTING_FOUNDATION.equals(editedRequirementCategory));
+
+        // different credits -> false
+        editedRequirementCategory = new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withCredits("14").build();
+        assertFalse(COMPUTING_FOUNDATION.equals(editedRequirementCategory));
+
+        // different codes -> false
+        editedRequirementCategory = new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withCodes("CS9999").build();
+        assertFalse(COMPUTING_FOUNDATION.equals(editedRequirementCategory));
+    }
+
+}

--- a/src/test/java/pwe/planner/model/requirement/UniqueRequirementCategoryListTest.java
+++ b/src/test/java/pwe/planner/model/requirement/UniqueRequirementCategoryListTest.java
@@ -1,0 +1,201 @@
+package pwe.planner.model.requirement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static pwe.planner.testutil.TypicalRequirementCategories.COMPUTING_BREADTH;
+import static pwe.planner.testutil.TypicalRequirementCategories.COMPUTING_FOUNDATION;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import pwe.planner.model.module.Code;
+import pwe.planner.model.module.Credits;
+import pwe.planner.model.module.Name;
+import pwe.planner.model.requirement.exceptions.DuplicateRequirementCategoryException;
+import pwe.planner.model.requirement.exceptions.RequirementCategoryNotFoundException;
+import pwe.planner.testutil.RequirementCategoryBuilder;
+
+public class UniqueRequirementCategoryListTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final UniqueRequirementCategoryList uniqueRequirementCategoryList = new UniqueRequirementCategoryList();
+
+    @Test
+    public void contains_nullRequirementCategory_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.contains((RequirementCategory) null);
+    }
+
+    @Test
+    public void contains_nullRequirementCategoryName_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.contains((Name) null);
+    }
+
+    @Test
+    public void getRequirementCategoryByName_nullName_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.getRequirementCategory(null);
+    }
+
+    @Test
+    public void contains_requirementCategoryNameNotInList_returnsFalse() {
+        assertFalse(uniqueRequirementCategoryList.contains(new Name("SOMETHING")));
+    }
+
+    @Test
+    public void contains_requirementCategoryNotInList_returnsFalse() {
+        Set<Code> codeSet = Set.of(new Code("CS2100"));
+        RequirementCategory requirementCategory =
+                new RequirementCategory(new Name("SOMETHING"), new Credits("12"), codeSet);
+        assertFalse(uniqueRequirementCategoryList.contains(requirementCategory));
+    }
+
+
+    @Test
+    public void contains_requirementCategoryInList_returnsTrue() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        assertTrue(uniqueRequirementCategoryList.contains(COMPUTING_FOUNDATION));
+    }
+
+    @Test
+    public void add_nullRequirementCategory_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.add(null);
+    }
+
+    @Test
+    public void add_duplicateRequirementCategory_throwsDuplicateRequirementCategoryException() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        thrown.expect(DuplicateRequirementCategoryException.class);
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+    }
+
+    @Test
+    public void setRequirementCategory_nullTargetRequirementCategory_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.setRequirementCategory(null, COMPUTING_FOUNDATION);
+    }
+
+    @Test
+    public void setRequirementCategory_nullEditedRequirementCategory_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, null);
+    }
+
+    @Test
+    public void setRequirementCategory_targetRequirementCategoryNotInList_throwsRequirementCategoryNotFoundException() {
+        thrown.expect(RequirementCategoryNotFoundException.class);
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, COMPUTING_FOUNDATION);
+    }
+
+    @Test
+    public void setRequirementCategory_editedRequirementCategoryIsSameRequirementCategory_success() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, COMPUTING_FOUNDATION);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        expectedRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategory_editedRequirementCategoryHasSameIdentity_success() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        RequirementCategory editedRequirementCategory =
+                new RequirementCategoryBuilder(COMPUTING_FOUNDATION).withCodes("CS9999").build();
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, editedRequirementCategory);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        expectedRequirementCategoryList.add(editedRequirementCategory);
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategory_editedRequirementCategoryHasDifferentIdentity_success() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, COMPUTING_BREADTH);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        expectedRequirementCategoryList.add(COMPUTING_BREADTH);
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategory_editedRequirementCategoryNonUniqueIdentity_throwsDuplicateReqCatException() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        uniqueRequirementCategoryList.add(COMPUTING_BREADTH);
+        thrown.expect(DuplicateRequirementCategoryException.class);
+        uniqueRequirementCategoryList.setRequirementCategory(COMPUTING_FOUNDATION, COMPUTING_BREADTH);
+    }
+
+    @Test
+    public void remove_nullRequirementCategory_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.remove(null);
+    }
+
+    @Test
+    public void remove_requirementCategoryDoesNotExist_throwsRequirementCategoryNotFoundException() {
+        thrown.expect(RequirementCategoryNotFoundException.class);
+        uniqueRequirementCategoryList.remove(COMPUTING_FOUNDATION);
+    }
+
+    @Test
+    public void remove_existingRequirementCategory_removesRequirementCategory() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        uniqueRequirementCategoryList.remove(COMPUTING_FOUNDATION);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategories_nullUniqueRequirementCategoryList_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.setRequirementCategories((UniqueRequirementCategoryList) null);
+    }
+
+    @Test
+    public void setRequirementCategories_uniqueRequirementCategoryList_replacesOwnListWithProvidedUniqueReqCatList() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        expectedRequirementCategoryList.add(COMPUTING_BREADTH);
+        uniqueRequirementCategoryList.setRequirementCategories(expectedRequirementCategoryList);
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategories_nullList_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueRequirementCategoryList.setRequirementCategories((List<RequirementCategory>) null);
+    }
+
+    @Test
+    public void setRequirementCategories_list_replacesOwnListWithProvidedList() {
+        uniqueRequirementCategoryList.add(COMPUTING_FOUNDATION);
+        List<RequirementCategory> requirementCategoryList = Collections.singletonList(COMPUTING_BREADTH);
+        uniqueRequirementCategoryList.setRequirementCategories(requirementCategoryList);
+        UniqueRequirementCategoryList expectedRequirementCategoryList = new UniqueRequirementCategoryList();
+        expectedRequirementCategoryList.add(COMPUTING_BREADTH);
+        assertEquals(expectedRequirementCategoryList, uniqueRequirementCategoryList);
+    }
+
+    @Test
+    public void setRequirementCategories_listWithDuplicateRequirementCategory_throwsDuplicateReqCatException() {
+        List<RequirementCategory> listWithRequirementCategory =
+                Arrays.asList(COMPUTING_FOUNDATION, COMPUTING_FOUNDATION);
+        thrown.expect(DuplicateRequirementCategoryException.class);
+        uniqueRequirementCategoryList.setRequirementCategories(listWithRequirementCategory);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        thrown.expect(UnsupportedOperationException.class);
+        uniqueRequirementCategoryList.asUnmodifiableObservableList().remove(0);
+    }
+}


### PR DESCRIPTION
Currently, there are no tests for `RequirementCategory`and 
`UniqueRequirementCategoryList` classes.

The `requirement_add` command test cases also need to be updated to
reflect the current implementation of our application.

Let's add and update the test cases for the above-mentioned classes.